### PR TITLE
Allow loading USB root payloads when enabled

### DIFF
--- a/include/payload_mgr.h
+++ b/include/payload_mgr.h
@@ -24,6 +24,7 @@ int payload_mgr_repository_push_json(const char *json, size_t len);
 int payload_mgr_usb_check(const char *usb_path, char *out_json, size_t out_size);
 int payload_mgr_usb_move(const char *usb_path, int overwrite, char *out_json, size_t out_size);
 
+int read_config_bool(const char *key, int default_val);
 int payload_mgr_check_self_update(char *out_path, size_t out_size);
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -6,6 +6,7 @@
  */
 
 #include <arpa/inet.h>
+#include <ctype.h>
 #include <microhttpd.h>
 #include <signal.h>
 #include <stdint.h>
@@ -240,6 +241,16 @@ static int is_allowed_payload_path(const char *path) {
       return 1;
     }
   }
+
+  if (read_config_bool("SCAN_USB_PAYLOADS", 0)) {
+    size_t len = strlen(path);
+    if (len >= 10 && strncmp(path, "/mnt/usb", 8) == 0 &&
+        isdigit((unsigned char)path[8]) && path[9] == '/' &&
+        strchr(path + 10, '/') == NULL) {
+      return 1;
+    }
+  }
+
   return 0;
 }
 

--- a/src/payload_mgr.c
+++ b/src/payload_mgr.c
@@ -831,7 +831,7 @@ static int is_allowed_usb_path(const char *path) {
         return -1;
     }
 
-    static int read_config_bool(const char *key, int default_val) {
+    int read_config_bool(const char *key, int default_val) {
         FILE *f = fopen(PLDMGR_CONFIG_PATH, "r");
         if (!f) return default_val;
         char line[256];


### PR DESCRIPTION
I found it always fails when sending a payload from usb root.