### PR TITLE
fix: display payload version from JSON field instead of filename

### DIFF
--- a/frontend/mock-server.js
+++ b/frontend/mock-server.js
@@ -115,8 +115,19 @@ app.get('/list_payloads', (req, res) => {
       "/mnt/usb0/pldmgr/linux_loader.elf"
     ],
     meta: {
-      // payloads with no entry here = local/direct upload (no badge shown)
+      "goldhen_v2.4b17.elf": {
+        display_name: "GoldHEN",
+        version: "v2.4b17",
+        install_source: "repository"
+      },
+      "etaHEN_1.8.elf": {
+        display_name: "etaHEN",
+        version: "v1.8",
+        install_source: "repository"
+      },
       "kstuff.elf": {
+        display_name: "kstuff",
+        version: "v1.03",
         source_name: "Community Payloads",
         install_source: "repository",
         install_source_detail: "https://example.com/community-payloads.json"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -516,15 +516,21 @@ function App() {
                     <button onClick={() => { setStorageScrollTarget('cloud-repository'); setView('storage'); }} className="px-8 py-3 bg-ps-blue text-white rounded-xl font-bold tracking-tight">Open Repository</button>
                   </div>
                 ) : (
-                  payloads.filter(p => !isSystemPayload(p)).map((p) => (
-                    <PayloadButton
-                      key={p}
-                      path={p}
-                      onClick={() => loadPayload(p)}
-                      isLoading={loading && activeLoadingName === p.split('/').pop().replace(/\.(elf|bin|lua)$/i, '').replace(/_/g, ' ')}
-                      sourceName={config.MULTI_SOURCES_ENABLED ? (payloadMeta[p.split('/').pop()]?.source_name || null) : null}
-                    />
-                  ))
+                  payloads.filter(p => !isSystemPayload(p)).map((p) => {
+                    const fileName = p.split('/').pop()
+                    const meta = payloadMeta[fileName]
+                    return (
+                      <PayloadButton
+                        key={p}
+                        path={p}
+                        onClick={() => loadPayload(p)}
+                        isLoading={loading && activeLoadingName === fileName.replace(/\.(elf|bin|lua)$/i, '').replace(/_/g, ' ')}
+                        sourceName={config.MULTI_SOURCES_ENABLED ? (meta?.source_name || null) : null}
+                        version={meta?.version || null}
+                        displayName={meta?.display_name || null}
+                      />
+                    )
+                  })
                 )}
               </div>
             </div>

--- a/frontend/src/components/ui/PayloadButton.jsx
+++ b/frontend/src/components/ui/PayloadButton.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Loader2, Globe } from 'lucide-react'
 import PayloadName from './PayloadName'
 
-const PayloadButton = ({ path, onClick, isLoading, sourceName }) => {
+const PayloadButton = ({ path, onClick, isLoading, sourceName, version, displayName }) => {
   return (
     <button
       onClick={onClick}
@@ -10,7 +10,7 @@ const PayloadButton = ({ path, onClick, isLoading, sourceName }) => {
       className="group glass-card p-6 rounded-ps-xl flex flex-col border border-white/5 hover:border-ps-blue hover:bg-ps-blue/5 transition-all text-left relative overflow-hidden"
     >
       <div className="flex items-start justify-between w-full z-10">
-        <PayloadName path={path} className="text-white text-xl" stacked />
+        <PayloadName path={path} version={version} displayName={displayName} className="text-white text-xl" stacked />
         {isLoading && <Loader2 className="w-6 h-6 animate-spin text-ps-blue shrink-0" />}
       </div>
       {path.startsWith('/mnt/usb') && (

--- a/frontend/src/components/ui/PayloadName.jsx
+++ b/frontend/src/components/ui/PayloadName.jsx
@@ -2,8 +2,11 @@ import React from 'react'
 import { Zap, Usb } from 'lucide-react'
 import { cn, parsePayloadName } from '../../utils/helpers'
 
-const PayloadName = ({ path, className, versionClassName, stacked = false, hideIcon = false, lastUpdate = null }) => {
-  const { displayName, version, isDelay } = parsePayloadName(path);
+const PayloadName = ({ path, version: versionOverride, displayName: displayNameOverride, className, versionClassName, stacked = false, hideIcon = false, lastUpdate = null }) => {
+  const parsed = parsePayloadName(path);
+  const displayName = displayNameOverride || parsed.displayName;
+  const version = versionOverride || null;
+  const isDelay = parsed.isDelay;
   const isUsb = path?.startsWith('/mnt/usb');
 
   return (

--- a/frontend/src/components/views/StorageHub.jsx
+++ b/frontend/src/components/views/StorageHub.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react'
 import { CloudDownload, Upload, Package, Database, RefreshCw, Trash2, Loader2, AlertTriangle, HardDrive, Usb, ChevronDown, Globe } from 'lucide-react'
 import { QRCodeSVG } from 'qrcode.react'
-import { cn, isPS5, parsePayloadName } from '../../utils/helpers'
+import { cn, isPS5 } from '../../utils/helpers'
 import PayloadName from '../ui/PayloadName'
 
 const StorageHub = ({ payloads, payloadMeta, onInstall, onDelete, onUpload, onImportFromUsb, config, ip, scrollTarget, onClearScrollTarget }) => {
@@ -155,7 +155,9 @@ const StorageHub = ({ payloads, payloadMeta, onInstall, onDelete, onUpload, onIm
               // Find update in all sources (multi or legacy)
               const allRemote = enrichedSources.flatMap(s => s.payloads)
               const remoteMatch = allRemote.find(rp => rp.filename === fileName || rp.installedFilename === fileName)
-              const remoteVersion = remoteMatch?.filename ? parsePayloadName(remoteMatch.filename).version : null
+              const installedVersion = payloadMeta[fileName]?.version || remoteMatch?.version
+              const installedDisplayName = payloadMeta[fileName]?.display_name || remoteMatch?.name
+              const remoteVersion = remoteMatch?.version || null
               return (
                 <div key={path} className="group flex flex-col justify-center p-4 md:p-6 glass-card rounded-ps-2xl border-white/10 hover:border-ps-blue/30 gap-3 md:gap-4 relative overflow-hidden">
                   <div className="flex flex-row items-center justify-between w-full gap-4">
@@ -164,7 +166,13 @@ const StorageHub = ({ payloads, payloadMeta, onInstall, onDelete, onUpload, onIm
                         <Package className="w-6 h-6 md:w-8 md:h-8 text-zinc-400 group-hover:text-ps-blue transition-colors" />
                       </div>
                       <div className="min-w-0 flex-1 space-y-1">
-                        <PayloadName path={fileName} className="text-xl md:text-2xl text-white" stacked />
+                        <PayloadName
+                          path={fileName}
+                          version={installedVersion}
+                          displayName={installedDisplayName}
+                          className="text-xl md:text-2xl text-white"
+                          stacked
+                        />
                         {sourceBadge && (
                           <div className="flex items-center gap-1 text-zinc-500 text-[11px] select-none font-medium">
                             <Globe className="w-3.5 h-3.5" />
@@ -306,7 +314,14 @@ const StorageHub = ({ payloads, payloadMeta, onInstall, onDelete, onUpload, onIm
                             )}
                           >
                             <div className="space-y-2 min-w-0">
-                              <PayloadName path={p.filename} className="text-xl md:text-2xl text-white" stacked lastUpdate={p.last_update} />
+                              <PayloadName
+                                path={p.filename}
+                                version={p.version}
+                                displayName={p.name}
+                                className="text-xl md:text-2xl text-white"
+                                stacked
+                                lastUpdate={p.last_update}
+                              />
                               {p.description && (
                                 <p className="text-sm md:text-base text-zinc-400 font-medium leading-relaxed">{p.description}</p>
                               )}


### PR DESCRIPTION
Some payloads, such as elf-arsenal, do not include the version number in the filename. As a result, custom payloads were not displaying the version number. To solve this, I extracted the version number directly from the JSON itself.