### PR TITLE
Fetch JSON directly from the github repo instead of gh page.

### DIFF
--- a/frontend/mock-server.js
+++ b/frontend/mock-server.js
@@ -58,7 +58,7 @@ const communityRepository = [
 let lastRepositoryUpdate = Math.floor(Date.now() / 1000);
 
 let mockSources = [
-  { id: 'default', name: 'Official Repository', url: 'https://itsplk.github.io/ps5-payloads-mirror/payloads.json', removable: false },
+  { id: 'default', name: 'Official Repository', url: 'https://raw.githubusercontent.com/itsPLK/ps5-payloads-mirror/refs/heads/main/payloads.json', removable: false },
   { id: 'source_community', name: 'Community Payloads', url: 'https://example.com/community-payloads.json', removable: true }
 ];
 

--- a/include/pldmgr.h
+++ b/include/pldmgr.h
@@ -43,7 +43,7 @@
 #define REPOSITORY_CACHE_PATH "/data/pldmgr/repository_cache.json"
 #define PAYLOADS_STORAGE_DIR "/data/pldmgr/payloads"
 #define REPOSITORY_SOURCE_URL                                                  \
-  "https://itsplk.github.io/ps5-payloads-mirror/payloads.json"
+  "https://raw.githubusercontent.com/itsPLK/ps5-payloads-mirror/refs/heads/main/payloads.json"
 #define REPOSITORY_REFRESH_INTERVAL_SEC 86400
 
 /* Logging (implementation in log_server.c) */


### PR DESCRIPTION
Instead of fetching the github pages link of `ps5-payloads-mirror`, I think it's better to get the raw JSON directly from the repo.

Here's why:
1. Currently the page and the repo are out of sync, and it's impossible to update kstuff lite, as the page returns a JSON of v1.08 while the repo is on v1.09.
2. That happened because the page build workflow crashed yet again.
3. While this issue can be fixed by updating the github pages workflow, I just think it's an unnecessary extra step that can be removed altogether. Its only purpose is serving the JSON anyway, unless I'm mistaken.
4. This one is just a note: I tried changing the default URL in `sources.json`, but it didn't update the internal one, I assume that's by design. This is also how I've been using [my own fork of ps5-payloads-mirror](https://github.com/mpaterakis/ps5-payloads-mirror), using just a raw link.

This change was tested on a 12.40 PS5 and I hope you consider it.
Regardless, **thank you very much for your work!**