### PR TITLE
fix(frontend): display version field from custom payload repositories

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -529,6 +529,7 @@ function App() {
                       onClick={() => loadPayload(p)}
                       isLoading={loading && activeLoadingName === p.split('/').pop().replace(/\.(elf|bin)$/i, '').replace(/_/g, ' ')}
                       sourceName={config.MULTI_SOURCES_ENABLED ? (payloadMeta[p.split('/').pop()]?.source_name || null) : null}
+                      version={payloadMeta[p.split('/').pop()]?.version || null}
                     />
                   ))
                 )}

--- a/frontend/src/components/ui/PayloadButton.jsx
+++ b/frontend/src/components/ui/PayloadButton.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Loader2, Globe } from 'lucide-react'
 import PayloadName from './PayloadName'
 
-const PayloadButton = ({ path, onClick, isLoading, sourceName }) => {
+const PayloadButton = ({ path, onClick, isLoading, sourceName, version }) => {
   return (
     <button
       onClick={onClick}
@@ -10,7 +10,7 @@ const PayloadButton = ({ path, onClick, isLoading, sourceName }) => {
       className="group glass-card p-6 rounded-ps-xl flex flex-col border border-white/5 hover:border-ps-blue hover:bg-ps-blue/5 transition-all text-left relative overflow-hidden"
     >
       <div className="flex items-start justify-between w-full z-10">
-        <PayloadName path={path} className="text-white text-xl" stacked />
+        <PayloadName path={path} version={version} className="text-white text-xl" stacked />
         {isLoading && <Loader2 className="w-6 h-6 animate-spin text-ps-blue shrink-0" />}
       </div>
       {path.startsWith('/mnt/usb') && (

--- a/frontend/src/components/ui/PayloadName.jsx
+++ b/frontend/src/components/ui/PayloadName.jsx
@@ -2,9 +2,11 @@ import React from 'react'
 import { Zap, Usb } from 'lucide-react'
 import { cn, parsePayloadName } from '../../utils/helpers'
 
-const PayloadName = ({ path, className, versionClassName, stacked = false, hideIcon = false, lastUpdate = null }) => {
-  const { displayName, version, isDelay } = parsePayloadName(path);
+const PayloadName = ({ path, version: repoVersion, className, versionClassName, stacked = false, hideIcon = false, lastUpdate = null }) => {
+  let { displayName, version, isDelay } = parsePayloadName(path);
   const isUsb = path?.startsWith('/mnt/usb');
+
+  if (repoVersion) version = repoVersion;
 
   return (
     <div className={cn("flex min-w-0 flex-1 w-full", stacked ? "flex-col items-stretch" : "items-center space-x-3", className)}>

--- a/frontend/src/components/views/StorageHub.jsx
+++ b/frontend/src/components/views/StorageHub.jsx
@@ -15,7 +15,7 @@ const PayloadItem = ({ p, multiSources, isPS5, onInstall, srcId, srcUrl }) => (
     )}
   >
     <div className="space-y-2 min-w-0">
-      <PayloadName path={p.filename} className="text-xl md:text-2xl text-white" stacked lastUpdate={p.last_update} />
+      <PayloadName path={p.filename} version={p.version} className="text-xl md:text-2xl text-white" stacked lastUpdate={p.last_update} />
       {p.description && (
         <p className="text-sm md:text-base text-zinc-400 font-medium leading-relaxed">{p.description}</p>
       )}
@@ -229,7 +229,7 @@ const StorageHub = ({ payloads, payloadMeta, onInstall, onDelete, onUpload, onIm
               // Find update in all sources (multi or legacy)
               const allRemote = enrichedSources.flatMap(s => s.payloads)
               const remoteMatch = allRemote.find(rp => rp.filename === fileName || rp.installedFilename === fileName)
-              const remoteVersion = remoteMatch?.filename ? parsePayloadName(remoteMatch.filename).version : null
+              const remoteVersion = remoteMatch?.version || (remoteMatch?.filename ? parsePayloadName(remoteMatch.filename).version : null)
               return (
                 <div key={path} className="group flex flex-col justify-center p-4 md:p-6 glass-card rounded-ps-2xl border-white/10 hover:border-ps-blue/30 gap-3 md:gap-4 relative overflow-hidden">
                   <div className="flex flex-row items-center justify-between w-full gap-4">


### PR DESCRIPTION
## Problem

`CUSTOM_REPOSITORIES.md` defines an item-level `version` field for custom payload repositories:

> **`version`** (item-level) | String | No | Version string used for update checks (e.g. `\"v1.0\"`).

But the frontend never reads it. The version is derived solely from the filename via regex in `parsePayloadName` (`frontend/src/utils/helpers.js`):

```js
const versionMatch = name.match(/[_-](v?\d+[\d.a-z-]+)/i);
```

Payloads whose filename has no version digits (e.g. `ps5-backpork.elf`, `CheatRunner.elf`, `elfldr-ps5.elf`) resolve to `version=null` → no version chip is shown, even when the repository JSON provides an explicit `version`.

## Root cause

Pure frontend gap. The backend already transmits `version`:

- **single-source**: `repository_list_json` (`src/repository.c`) memcpy's the raw cached JSON, which contains `version`.
- **multi-source**: `sources_multi_repository_list_json` (`src/sources.c`) re-serializes each payload and explicitly includes the `\"version\"` key; `parse_repository_payloads` extracts it at `repository.c:141`.
- **installed payloads**: `payload_mgr_list_json` reads sidecar `.json` and includes `version` in the per-filename `meta` object returned by `/list_payloads`.

So the version is already available in every view — it just isn't consumed by the frontend.

## Changes

Frontend-only edits (3 files, +3/-3):

1. **`PayloadName.jsx`** — accept a `version` prop. When a repository JSON provides a version (`repoVersion`), it overrides the value parsed from the filename. Rendering logic is unchanged.
2. **`StorageHub.jsx`** `PayloadItem` — pass `version={p.version}` (Cloud Repository list).
3. **`StorageHub.jsx`** Installed section — `remoteVersion` now prefers `remoteMatch.version`, falling back to filename parsing. The \"Update (to vX)\" button now reflects the repository's version.
4. **`App.jsx`** + **`PayloadButton.jsx`** — Dashboard payload cards now display the version from `/list_payloads` meta (sidecar `.json`), via `version={payloadMeta[filename]?.version}`.

No backend changes.

## Verification

- `vite build` passes (no errors).
- No regression for filename-with-version-but-no-JSON-`version` payloads (e.g. `ftpsrv_v0.19.elf`) — they still display via the filename fallback.
- `isDelay` payloads (path starts with `!`) render `version=null` — unchanged.
- Dashboard: payloads with sidecar `.json` containing `version` now show the version chip.

## Follow-ups (out of scope)

- **`isUpdate` detection** (`getBaseName` basename fuzzy match in `StorageHub.jsx`) could later be replaced by `compare_versions` against the `version` field (the backend already ships `compare_versions`).
