### PR TITLE
feat: move launcher icon to Media category

### DIFF
--- a/assets/param.json
+++ b/assets/param.json
@@ -1,4 +1,5 @@
 {
+    "applicationCategoryType": 65536,
     "titleId": "PLDM00001",
     "deeplinkUri": "http://127.0.0.1:8084/",
     "localizedParameters": {


### PR DESCRIPTION
## 动机

Payload Manager 启动器图标在 PS5 主屏默认归类在“游戏”分类下，与游戏内容混杂。本 PR 将其移动到“媒体”分类，使其与媒体类应用并列，主屏更整洁。

## 改动

在 `assets/param.json` 增加 `"applicationCategoryType": 65536`。

```json
{
    "applicationCategoryType": 65536,
    ...
}
```

## 验证

在 PS5 上实机验证：
- 启动器图标成功从“游戏”分类移动到“媒体”分类。
- 控制变量验证：仅 `applicationCategoryType: 65536` 单独生效。

## 影响范围

- 仅影响启动器应用图标在 PS5 主屏的分组位置。
- 不影响 daemon 功能、API、payload 管理等核心逻辑。
