### PR TITLE
fix(frontend): 跨源去重 payload 展示，避免重复 Update 卡片

### DIFF
--- a/frontend/src/components/views/StorageHub.jsx
+++ b/frontend/src/components/views/StorageHub.jsx
@@ -179,6 +179,30 @@ const StorageHub = ({ payloads, payloadMeta, onInstall, onDelete, onUpload, onIm
     return []
   }, [repoData, multiSources, localFilenames])
 
+  /* ---- Cross-source dedup (display only) ----
+   * When the same payload (by filename) appears in multiple sources, render it
+   * only under the highest-priority source (default/official first, then by
+   * source order) and record which other sources also carry it. Install logic
+   * is untouched — only the catalog view is deduplicated so users don't see
+   * duplicate "Update" cards for the same payload across sources. */
+  const dedupedSources = useMemo(() => {
+    const seen = new Map() // filename -> source name that owns it
+    return enrichedSources.map(src => {
+      const kept = []
+      const duplicates = []
+      for (const p of src.payloads) {
+        const owner = seen.get(p.filename)
+        if (owner) {
+          duplicates.push({ filename: p.filename, owner })
+        } else {
+          seen.set(p.filename, src.name)
+          kept.push(p)
+        }
+      }
+      return { ...src, payloads: kept, duplicates }
+    })
+  }, [enrichedSources])
+
   const legacyRepoUrl = repoData?.repo_url || ''
 
   /* ---- Source badge helper: look up source name from metadata ---- */
@@ -326,10 +350,10 @@ const StorageHub = ({ payloads, payloadMeta, onInstall, onDelete, onUpload, onIm
             </div>
             <button onClick={() => fetchRemote(true)} className="px-8 py-3 bg-white/5 border border-white/10 hover:bg-white/10 text-white rounded-xl font-bold uppercase text-xs transition-all">Retry Connection</button>
           </div>
-        ) : enrichedSources.length > 0 ? (
+        ) : dedupedSources.length > 0 ? (
           /* ===== REPOSITORY CATALOGS ===== */
           <div className="space-y-4">
-            {enrichedSources.map(src => {
+            {dedupedSources.map(src => {
               let availablePayloads = src.payloads.filter(p => !p.isInstalled || p.isUpdate)
               
               if (search.trim() !== '') {
@@ -342,7 +366,7 @@ const StorageHub = ({ payloads, payloadMeta, onInstall, onDelete, onUpload, onIm
               }
               
               // Auto-expand if there's only 1 source, otherwise respect state or active search
-              const isExpanded = (enrichedSources.length === 1) || expandedSource === src.id || search.trim() !== ''
+              const isExpanded = (dedupedSources.length === 1) || expandedSource === src.id || search.trim() !== ''
 
               let hasMultipleCategories = false
               let groupedPayloads = {}
@@ -411,10 +435,18 @@ const StorageHub = ({ payloads, payloadMeta, onInstall, onDelete, onUpload, onIm
                       </div>
                     </div>
                     <div className="flex items-center space-x-3">
+                      {src.duplicates?.length > 0 && (
+                        <span
+                          className="px-3 py-1 rounded-full bg-white/5 text-zinc-500 text-xs font-bold"
+                          title={src.duplicates.map(d => `${d.filename} (in ${d.owner})`).join('\n')}
+                        >
+                          {src.duplicates.length} hidden (in other sources)
+                        </span>
+                      )}
                       <span className="px-3 py-1 rounded-full bg-white/5 text-zinc-500 text-xs font-bold">
                         {availablePayloads.length} available
                       </span>
-                      {enrichedSources.length > 1 && (
+                      {dedupedSources.length > 1 && (
                         <ChevronDown className={cn("w-5 h-5 text-zinc-500 transition-transform", isExpanded && "rotate-180")} />
                       )}
                     </div>


### PR DESCRIPTION
## 问题

`ps5-payload-manager` 内置 `default`（itsPLK 官方源，`removable=false`）。用户再添加第三方源（如 `lucaszhongsj/ps5-payloads-atlas`）后，同一 payload 在两个源都存在时：

- `enrichedSources` 按 source 分组独立渲染
- 每个 source 各自计算 `isUpdate`（按 `getBaseName(filename)` 匹配本地）
- 结果：同 payload 显示 N 张卡片，N 个 Update 入口，**即使版本号完全相同**

## 修复

新增 `dedupedSources` useMemo：遍历所有 source，按 `filename` 去重。payload 只渲染在第一个出现的 source（default/官方源在 index 0，永远优先），其余 source 中重复项记录到 `src.duplicates`，在 source header 显示 `N hidden (in other sources)` 计数 + hover 详情。

**只动展示层**：
- 安装逻辑不变（`PayloadItem` 仍用 `srcId`/`srcUrl` 跳转）
- installed 区更新检测不变（L254 仍用 `enrichedSources.flatMap` 全量查找）
- sources.json、后端、API 全部不动

## 改动范围

`frontend/src/components/views/StorageHub.jsx` +36 -4

## 验证

- token 检查通过（dedupedSources / src.duplicates / hidden 文案均在）
- eslint 未跑（本地无 node_modules，需 CI 验证）
- 行为等价：单源场景 `dedupedSources === enrichedSources`（seen 永远空）

## 风险

- 若某 source 仅含重复 payload（被完全 hidden），其分组仍显示 header + `0 available` + `N hidden` 文案，可能让用户困惑。后续可考虑空分组自动折叠，但作为首版修复刻意保持简单。