### PR TITLE
Cyberpunk 2077 theme + dual-theme system (classic preserved)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ frontend-build:
 	TITLE="Payload Manager v$$VERSION by PLK ($$COMMIT, built at $$DATE)"; \
 	echo "Updating title in index.html to: $$TITLE"; \
 	TMP=$$(mktemp "$${TMPDIR:-/tmp}/pldmgr.XXXXXX"); \
-	sed "s|\[\[TITLE_PLACEHOLDER\]\]|$$TITLE|g" frontend/dist/index.html > $$TMP; \
+	sed "s|<title>Payload Manager</title>|<title>$$TITLE</title>|g" frontend/dist/index.html > $$TMP; \
 	mv $$TMP frontend/dist/index.html; \
 	echo "Updating build date in cache.appcache to: $$DATE"; \
 	TMP=$$(mktemp "$${TMPDIR:-/tmp}/pldmgr.XXXXXX"); \

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you are using an older version and don't want to update the entire autoloader
 2. Add `pldmgr.elf` as the only entry in your `autoload.txt` config file.
 
 ### Standalone / Manual Loading
-You can also manually load the manager like any other `.elf` file. Grab the latest version from the [Releases](https://github.com/amilarajans/ps5-payload-manager/releases) page.
+You can also manually load the manager like any other `.elf` file. Grab the latest version from the [Releases](https://github.com/itsPLK/ps5-payload-manager/releases) page.
 
 ## Custom Repositories
 You can add third-party payload repositories to the manager. To learn how to create your own repository JSON and host it, see the [Custom Repositories Guide](CUSTOM_REPOSITORIES.md).

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you are using an older version and don't want to update the entire autoloader
 2. Add `pldmgr.elf` as the only entry in your `autoload.txt` config file.
 
 ### Standalone / Manual Loading
-You can also manually load the manager like any other `.elf` file. Grab the latest version from the [Releases](https://github.com/itsPLK/ps5-payload-manager/releases) page.
+You can also manually load the manager like any other `.elf` file. Grab the latest version from the [Releases](https://github.com/amilarajans/ps5-payload-manager/releases) page.
 
 ## Custom Repositories
 You can add third-party payload repositories to the manager. To learn how to create your own repository JSON and host it, see the [Custom Repositories Guide](CUSTOM_REPOSITORIES.md).

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,8 @@
 
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <!-- Default classic favicon; applyThemeVars swaps SVG per theme at runtime -->
+    <link rel="icon" type="image/svg+xml" href="/favicon-classic.svg" data-theme-favicon="1" />
     <link rel="icon" type="image/png" href="/icon.png" />
     <link rel="apple-touch-icon" href="/icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,8 @@
     <link rel="icon" type="image/png" href="/icon.png" />
     <link rel="apple-touch-icon" href="/icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>[[TITLE_PLACEHOLDER]]</title>
+    <!-- Dev: plain name. Release make frontend-build replaces this with versioned title. -->
+    <title>Payload Manager</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,8 +9,8 @@
   ],
   "scripts": {
     "dev": "vite",
-    "mock": "node mock-server.js",
-    "dev:mock": "concurrently \"npm run mock\" \"npm run dev\"",
+    "mock": "bun mock-server.js",
+    "dev:mock": "concurrently -k \"bun run mock\" \"bun run dev\"",
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",

--- a/frontend/public/favicon-classic.svg
+++ b/frontend/public/favicon-classic.svg
@@ -1,5 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
-  <!-- Default = classic (matches DEFAULT_THEME). applyThemeVars swaps href at runtime. -->
   <rect width="512" height="512" rx="112" fill="#08080a"/>
   <rect x="48" y="48" width="416" height="416" rx="80" fill="none" stroke="#0095ff" stroke-width="24"/>
   <g transform="translate(60, 64) scale(16)" fill="#0095ff">

--- a/frontend/public/favicon-cyberpunk.svg
+++ b/frontend/public/favicon-cyberpunk.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" rx="48" fill="#0a0508"/>
+  <rect x="48" y="48" width="416" height="416" rx="24" fill="none" stroke="#ff3c3c" stroke-width="24"/>
+  <g transform="translate(60, 64) scale(16)" fill="#fcee0a">
+    <rect x="2" y="4" width="2.5" height="16" rx="0.5"/>
+    <rect x="7.5" y="7" width="4" height="4" rx="0.5"/>
+    <rect x="13" y="7" width="4" height="4" rx="0.5"/>
+    <rect x="18.5" y="7" width="4" height="4" rx="0.5"/>
+    <rect x="7.5" y="13" width="4" height="4" rx="0.5"/>
+    <rect x="13" y="13" width="4" height="4" rx="0.5"/>
+    <rect x="18.5" y="13" width="4" height="4" rx="0.5"/>
+  </g>
+</svg>

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,6 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
-  <rect width="512" height="512" rx="112" fill="#0095ff"/>
-  <g transform="translate(60, 64) scale(16)" fill="#ffffff">
+  <rect width="512" height="512" rx="112" fill="#0a080c"/>
+  <rect x="48" y="48" width="416" height="416" rx="80" fill="none" stroke="#fcee0a" stroke-width="24"/>
+  <g transform="translate(60, 64) scale(16)" fill="#fcee0a">
     <!-- Sidebar Line -->
     <rect x="2" y="4" width="2.5" height="16" rx="1"/>
     

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,11 +1,16 @@
 /* Minimal Component Styles */
+main.custom-scrollbar {
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+}
+
 .custom-scrollbar::-webkit-scrollbar {
   width: 4px;
 }
 
 .custom-scrollbar::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.1);
-  border-radius: 2px;
+  background: var(--color-scrollbar);
+  border-radius: 4px;
 }
 
 .custom-scrollbar::-webkit-scrollbar-thumb:hover {

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -27,6 +27,7 @@ import PayloadButton from './components/ui/PayloadButton'
 import LogoIcon from './components/ui/LogoIcon'
 import Atmosphere from './components/ui/Atmosphere'
 import HudBar from './components/ui/HudBar'
+import HudButton from './components/ui/HudButton'
 import { useTheme } from './theme/ThemeContext'
 
 // Views
@@ -428,8 +429,12 @@ function App() {
         onClose={() => setConfirmModal({ show: false })}
         footer={
           <>
-            <button onClick={() => setConfirmModal({ show: false })} className="flex-1 px-8 py-5 rounded-2xl bg-white/5 hover:bg-white/10 text-white font-bold transition-all uppercase tracking-tight">{t("app.buttons.cancel", "Cancel")}</button>
-            <button onClick={confirmModal.onConfirm} className="flex-1 px-8 py-5 rounded-2xl bg-red-600 hover:bg-red-500 text-white font-bold transition-all uppercase tracking-tight">{t("app.buttons.confirm", "Confirm")}</button>
+            <HudButton onClick={() => setConfirmModal({ show: false })} variant="secondary" size="lg" className="flex-1">
+              {t("app.buttons.cancel", "Cancel")}
+            </HudButton>
+            <HudButton onClick={confirmModal.onConfirm} variant="danger" size="lg" className="flex-1">
+              {t("app.buttons.confirm", "Confirm")}
+            </HudButton>
           </>
         }
       >
@@ -439,23 +444,33 @@ function App() {
       <aside className={cn(
         "cp-sidebar transition-all duration-500 z-[100] shrink-0 self-stretch",
         isPS5 ? "flex" : "hidden md:flex",
-        sidebarExpanded ? "w-80" : "w-24"
+        sidebarExpanded ? "w-80 cp-sidebar--expanded" : "w-[4.75rem] cp-sidebar--collapsed"
       )}>
-        {/* Yellow hazard stripe ΓÇö cyberpunk only (height 0 in classic via CSS) */}
+        {/* Yellow hazard stripe — cyberpunk only (height 0 in classic via CSS) */}
         <div className="cp-hazard shrink-0" aria-hidden="true" />
         <div className="cp-sidebar__inner">
-          <div className="cp-sidebar__brand">
+          <div className={cn(
+            "cp-sidebar__brand",
+            !sidebarExpanded && "cp-sidebar__brand--collapsed"
+          )}>
             <button
               onClick={() => setSidebarExpanded(!sidebarExpanded)}
-              className="p-3 bg-white/5 hover:bg-ps-yellow hover:text-black rounded-lg transition-all mr-4 shrink-0 border border-white/10"
+              className={cn(
+                "cp-sidebar__toggle p-2.5 bg-white/5 hover:bg-ps-blue hover:text-white rounded-xl transition-all shrink-0",
+                sidebarExpanded && "mr-3"
+              )}
+              aria-label={sidebarExpanded ? "Collapse sidebar" : "Expand sidebar"}
             >
-              <Menu className="w-6 h-6" />
+              <Menu className="w-5 h-5" />
             </button>
-            <div className={cn("flex items-center space-x-3 transition-all duration-500", sidebarExpanded ? "opacity-100 scale-100" : "opacity-0 scale-90 absolute pointer-events-none")}>
-              <div className="p-2 rounded-lg cp-brand-icon">
+            <div className={cn(
+              "flex items-center space-x-3 transition-all duration-300 min-w-0",
+              sidebarExpanded ? "opacity-100 scale-100" : "opacity-0 scale-90 w-0 overflow-hidden pointer-events-none absolute"
+            )}>
+              <div className="p-2 rounded-lg cp-brand-icon shrink-0">
                 <LogoIcon className="w-6 h-6" />
               </div>
-              <span className="text-xl cp-brand cp-glitch">PLDMGR</span>
+              <span className="text-xl cp-brand cp-glitch truncate">PLDMGR</span>
             </div>
           </div>
 
@@ -539,7 +554,13 @@ function App() {
                       <p className="text-white font-extrabold tracking-tight text-2xl">{t("app.dashboard.empty.title", "Empty Library")}</p>
                       <p className="text-zinc-500 font-medium">{t("app.dashboard.empty.message", "Add payloads from the Cloud Hub to get started.")}</p>
                     </div>
-                    <button onClick={() => { setStorageScrollTarget('cloud-repository'); setView('storage'); }} className="px-8 py-3 bg-ps-blue text-white rounded-xl font-bold tracking-tight">{t("app.dashboard.empty.button", "Open Repository")}</button>
+                    <HudButton
+                      onClick={() => { setStorageScrollTarget('cloud-repository'); setView('storage'); }}
+                      variant="primary"
+                      size="lg"
+                    >
+                      {t("app.dashboard.empty.button", "Open Repository")}
+                    </HudButton>
                   </div>
                 ) : (
                   payloads.filter(p => !isSystemPayload(p)).map((p) => (
@@ -643,20 +664,22 @@ function App() {
         </div>
       )}
       {showLogs && (
-        <div className="fixed inset-0 z-[9999] bg-[#08080a] flex flex-col animate-in fade-in duration-300">
-          <div className="p-6 md:p-8 border-b border-white/10 flex items-center justify-between bg-[#08080a]/95 backdrop-blur-xl sticky top-0 z-10">
-            <div className="flex items-center space-x-4">
-              <Terminal className="w-8 h-8 text-ps-blue" />
-              <h3 className="text-3xl font-black text-white uppercase italic tracking-tighter">{t("app.logs.title", "Logs")}</h3>
+        <div className="cp-log-overlay fixed inset-0 z-[9999] flex flex-col animate-in fade-in duration-300">
+          <header className="cp-log-overlay__header">
+            <div className="cp-log-overlay__title">
+              <Terminal className="w-7 h-7 md:w-8 md:h-8 shrink-0 text-ps-blue" />
+              <h3>{t("app.logs.title", "Logs")}</h3>
             </div>
-            <button
+            <HudButton
               onClick={() => setShowLogs(false)}
-              className="p-4 rounded-2xl bg-white/5 hover:bg-red-600 hover:text-white transition-all border border-white/10 group"
-            >
-              <X className="w-8 h-8 transition-transform group-hover:rotate-90" />
-            </button>
-          </div>
-          <div className="flex-1 overflow-hidden bg-black/20">
+              icon={X}
+              variant="secondary"
+              size="sm"
+              className="cp-btn--icon"
+              aria-label={t("app.buttons.close", "Close")}
+            />
+          </header>
+          <div className="cp-log-overlay__body min-h-0 flex-1">
             <LogViewer logs={logs} />
           </div>
         </div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,6 +25,9 @@ import Modal from './components/ui/Modal'
 import NavButton from './components/ui/NavButton'
 import PayloadButton from './components/ui/PayloadButton'
 import LogoIcon from './components/ui/LogoIcon'
+import Atmosphere from './components/ui/Atmosphere'
+import HudBar from './components/ui/HudBar'
+import { useTheme } from './theme/ThemeContext'
 
 // Views
 import StorageHub from './components/views/StorageHub'
@@ -38,7 +41,9 @@ import ManageSourcesView from './components/views/ManageSourcesView'
 import ActiveProcessesView from './components/views/ActiveProcessesView'
 
 function App() {
-  const { t } = useTranslation();
+  const { t } = useTranslation()
+  const { themeId } = useTheme()
+  const isCyberpunk = themeId === 'cyberpunk'
   const [view, setView] = useState('dashboard')
   const mainRef = useRef(null)
 
@@ -200,10 +205,10 @@ function App() {
     input.value = ''
     if (!file) return
 
-    const ext = file.name.split('.').pop().toLowerCase();
-    if (ext !== 'elf' && ext !== 'bin') {
-      addToast(t("app.toasts.unsupported_file", "Unsupported file type. Only .elf and .bin files are allowed."), "error");
-      return;
+    // Only allow .elf and .bin files (lua dropped in v0.3.3+)
+    if (!/\.(elf|bin)$/i.test(file.name)) {
+      addToast(t("app.toasts.unsupported_file", "Unsupported file type. Only .elf and .bin files are allowed."), "error")
+      return
     }
 
     try {
@@ -388,10 +393,15 @@ function App() {
   return (
 
 
-    <div className={cn(
-      "min-h-screen min-h-[100dvh] ps5-bg text-zinc-100 font-ps5 flex",
-      isPS5 ? "flex-row overflow-hidden" : "flex-col md:flex-row md:overflow-hidden"
-    )}>
+    <div className={cn("app-shell ps5-bg text-zinc-100 font-ps5", `theme-${themeId}`)}>
+      {/* Cyberpunk-only chrome ΓÇö unmounted on classic so no leftover layout/DOM */}
+      {isCyberpunk && <Atmosphere />}
+      {isCyberpunk && <HudBar version={version} ip={ip} />}
+
+      <div className={cn(
+        "app-body relative z-[1]",
+        isPS5 ? "flex-row" : "flex-col md:flex-row"
+      )}>
       {/* Toast Container */}
       <div className="fixed top-0 right-0 p-8 z-[2000] space-y-4 pointer-events-none">
         {toasts.map(t => (
@@ -407,7 +417,7 @@ function App() {
             <span className="text-white font-bold text-xl">{downloadModal.progress}%</span>
           </div>
           <div className="h-4 bg-white/5 rounded-full overflow-hidden border border-white/10 p-0.5">
-            <div className="h-full bg-ps-blue rounded-full transition-all duration-500" style={{ width: `${downloadModal.progress}%` }} />
+            <div className="h-full cp-progress-fill rounded-full transition-all duration-500" style={{ width: `${downloadModal.progress}%` }} />
           </div>
         </div>
       </Modal>
@@ -427,27 +437,29 @@ function App() {
       </Modal>
 
       <aside className={cn(
-        "flex-col bg-black/40 border-r border-white/5 transition-all duration-500 z-[100] h-screen",
+        "cp-sidebar transition-all duration-500 z-[100] shrink-0 self-stretch",
         isPS5 ? "flex" : "hidden md:flex",
         sidebarExpanded ? "w-80" : "w-24"
       )}>
-        <div className="p-6 flex flex-col h-full">
-          <div className="flex items-center mb-12 h-10">
+        {/* Yellow hazard stripe ΓÇö cyberpunk only (height 0 in classic via CSS) */}
+        <div className="cp-hazard shrink-0" aria-hidden="true" />
+        <div className="cp-sidebar__inner">
+          <div className="cp-sidebar__brand">
             <button
               onClick={() => setSidebarExpanded(!sidebarExpanded)}
-              className="p-3 bg-white/5 hover:bg-ps-blue hover:text-white rounded-xl transition-all mr-4 shrink-0"
+              className="p-3 bg-white/5 hover:bg-ps-yellow hover:text-black rounded-lg transition-all mr-4 shrink-0 border border-white/10"
             >
               <Menu className="w-6 h-6" />
             </button>
             <div className={cn("flex items-center space-x-3 transition-all duration-500", sidebarExpanded ? "opacity-100 scale-100" : "opacity-0 scale-90 absolute pointer-events-none")}>
-              <div className="p-2 bg-ps-blue rounded-xl">
-                <LogoIcon className="w-6 h-6 text-white" />
+              <div className="p-2 rounded-lg cp-brand-icon">
+                <LogoIcon className="w-6 h-6" />
               </div>
-              <span className="text-2xl font-bold tracking-tight text-white">PLDMGR</span>
+              <span className="text-xl cp-brand cp-glitch">PLDMGR</span>
             </div>
           </div>
 
-          <nav className="flex-1 space-y-2">
+          <nav className="cp-sidebar__nav">
             <NavButton sidebar sidebarExpanded={sidebarExpanded} active={view === 'dashboard'} onClick={() => setView('dashboard')} icon={LayoutDashboard} label={t("app.nav.dashboard", "Dashboard")} />
             <NavButton sidebar sidebarExpanded={sidebarExpanded} active={view === 'storage'} onClick={() => setView('storage')} icon={Database} label={t("app.nav.storage", "Manage Payloads")} />
             <NavButton sidebar sidebarExpanded={sidebarExpanded} active={view === 'autoload'} onClick={() => setView('autoload')} icon={RefreshCw} label={t("app.nav.autoload", "Autoload")} />
@@ -455,7 +467,7 @@ function App() {
             <NavButton sidebar sidebarExpanded={sidebarExpanded} active={view === 'settings'} onClick={() => setView('settings')} icon={Settings} label={t("app.nav.settings", "Settings")} />
           </nav>
 
-          <div className="pt-6 border-t border-white/5">
+          <div className="cp-sidebar__foot">
             <NavButton
               sidebar
               sidebarExpanded={sidebarExpanded}
@@ -463,7 +475,6 @@ function App() {
               onClick={() => setView('donate')}
               icon={Heart}
               label={t("app.nav.donate", "Donate")}
-              className={view === 'donate' ? "bg-red-600" : "text-red-500 hover:bg-red-600/10"}
               isDonate
             />
           </div>
@@ -472,7 +483,7 @@ function App() {
 
       {/* MOBILE BOTTOM NAV */}
       <nav className={cn(
-        "fixed bottom-0 inset-x-0 z-[100] bg-black/80 border-t border-white/5 h-[calc(5rem+env(safe-area-inset-bottom))] pb-[env(safe-area-inset-bottom)] flex items-center overflow-x-auto hide-scrollbar",
+        "fixed bottom-0 inset-x-0 z-[100] bg-[#0a0508]/95 border-t border-red-500/30 h-[calc(5rem+env(safe-area-inset-bottom))] pb-[env(safe-area-inset-bottom)] flex items-center overflow-x-auto hide-scrollbar",
         isPS5 ? "hidden" : "md:hidden"
       )}>
         <NavButton active={view === 'dashboard'} onClick={() => setView('dashboard')} icon={LayoutDashboard} label={t("app.nav.dashboard", "Dashboard")} mobileLabel={t("app.nav.home_mobile", "Home")} />
@@ -491,19 +502,24 @@ function App() {
         />
       </nav>
 
-      {/* MAIN CONTENT AREA */}
-      <div className={cn(
-        "flex flex-col relative",
-        isPS5 ? "h-screen flex-1 min-h-0" : "md:h-screen md:flex-1 md:min-h-0"
-      )}>
-        <main ref={mainRef} className={cn(
-          "custom-scrollbar max-w-[1800px] mx-auto w-full flex flex-col",
-          isPS5 ? "pt-16 px-16 pb-12 flex-1 overflow-y-auto" : "pt-6 px-6 pb-36 md:pt-16 md:px-16 md:pb-12 md:flex-1 md:overflow-y-auto"
-        )}>
+      {/* MAIN CONTENT AREA ΓÇö app-main is the only vertical scrollport */}
+      <div className="app-main-wrap">
+        <main
+          ref={mainRef}
+          className={cn(
+            "app-main custom-scrollbar",
+            isPS5
+              ? "pt-8 px-16 pb-12"
+              : isCyberpunk
+                ? "pt-8 px-6 pb-36 md:pt-10 md:px-16 md:pb-12"
+                : "pt-6 px-6 pb-36 md:pt-10 md:px-16 md:pb-12"
+          )}
+        >
           {view === 'dashboard' && (
             <div className="space-y-8 md:space-y-12">
-              <h2 className="text-4xl font-extrabold text-white tracking-tight">
-                {t("app.dashboard.title_1", "Launch")} <span className="text-ps-blue">{t("app.dashboard.title_2", "Payload")}</span>
+              <h2 className="text-4xl font-extrabold tracking-widest">
+                <span className="cp-title-accent">{t("app.dashboard.title_1", "Launch")}</span>{' '}
+                <span className="text-white">{t("app.dashboard.title_2", "Payload")}</span>
               </h2>
               <div className={cn(
                 "grid gap-4 md:gap-6",
@@ -615,12 +631,13 @@ function App() {
           {view === 'donate' && <DonateView />}
         </main>
       </div>
+      </div>{/* end body row under HUD */}
 
       {loading && (
         <div className="fixed inset-0 bg-ps-black/95 z-[9999] flex flex-col items-center justify-center space-y-12">
           <div className="ps5-robust-spinner" />
           <div className="text-center">
-            <h4 className="text-4xl font-extrabold text-white tracking-tight mb-4 uppercase italic">{activeLoadingName || t("app.loading.title", "Launching...")}</h4>
+            <h4 className="cp-glitch cp-glitch-flicker text-4xl font-extrabold text-white tracking-tight mb-4 uppercase italic">{activeLoadingName || t("app.loading.title", "Launching...")}</h4>
             <p className="label-caps !text-ps-blue tracking-[0.3em] font-black">{t("app.loading.subtitle", "LAUNCHING PAYLOAD...")}</p>
           </div>
         </div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -372,6 +372,30 @@ function App() {
 
 
   if (isOffline) {
+    /* Classic: original simple offline card. Cyberpunk: FLATLINED death screen. */
+    if (!isCyberpunk) {
+      return (
+        <div className="min-h-screen ps5-bg text-zinc-100 font-ps5 flex flex-col items-center justify-center p-4 text-center" data-theme={themeId}>
+          <div className="max-w-lg p-12 bg-black/40 rounded-3xl border border-white/5">
+            <h1 className="text-2xl font-bold mb-4 text-zinc-300">
+              {t("app.offline.title", "Payload Manager is not running...")}
+            </h1>
+            <p className="text-lg text-zinc-400 leading-relaxed">
+              {t("app.offline.message_1", "Please ensure you have loaded")}{" "}
+              <strong>pldmgr.elf</strong>{" "}
+              {t("app.offline.message_2", "on your PS5 before launching this application.")}
+            </p>
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              className="mt-8 px-8 py-3 bg-ps-blue hover:bg-ps-blue/80 text-white rounded-xl font-bold transition-colors"
+            >
+              {t("app.offline.retry", "Retry")}
+            </button>
+          </div>
+        </div>
+      )
+    }
     return (
       <div className={cn('app-shell ps5-bg', `theme-${themeId}`)} data-theme={themeId}>
         <FlatlinedScreen onRetry={() => window.location.reload()} />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -44,8 +44,7 @@ import ActiveProcessesView from './components/views/ActiveProcessesView'
 
 function App() {
   const { t } = useTranslation()
-  const { themeId } = useTheme()
-  const isCyberpunk = themeId === 'cyberpunk'
+  const { themeId, hasFeature } = useTheme()
   const [view, setView] = useState('dashboard')
   const mainRef = useRef(null)
 
@@ -372,8 +371,8 @@ function App() {
 
 
   if (isOffline) {
-    /* Classic: original simple offline card. Cyberpunk: FLATLINED death screen. */
-    if (!isCyberpunk) {
+    /* flatlinedError themes get the death screen; others keep the simple card. */
+    if (!hasFeature('flatlinedError')) {
       return (
         <div className="min-h-screen ps5-bg text-zinc-100 font-ps5 flex flex-col items-center justify-center p-4 text-center" data-theme={themeId}>
           <div className="max-w-lg p-12 bg-black/40 rounded-3xl border border-white/5">
@@ -416,9 +415,9 @@ function App() {
 
 
     <div className={cn("app-shell ps5-bg text-zinc-100 font-ps5", `theme-${themeId}`)}>
-      {/* Cyberpunk-only chrome ΓÇö unmounted on classic so no leftover layout/DOM */}
-      {isCyberpunk && <Atmosphere />}
-      {isCyberpunk && <HudBar version={version} ip={ip} />}
+      {/* Feature-gated chrome — unmounted when the theme pack disables them */}
+      {hasFeature('atmosphere') && <Atmosphere />}
+      {hasFeature('hudBar') && <HudBar version={version} ip={ip} />}
 
       <div className={cn(
         "app-body relative z-[1]",
@@ -467,8 +466,10 @@ function App() {
         isPS5 ? "flex" : "hidden md:flex",
         sidebarExpanded ? "w-80 cp-sidebar--expanded" : "w-[4.75rem] cp-sidebar--collapsed"
       )}>
-        {/* Yellow hazard stripe — cyberpunk only (height 0 in classic via CSS) */}
-        <div className="cp-hazard shrink-0" aria-hidden="true" />
+        {/* Yellow hazard stripe — feature-gated chrome */}
+        {hasFeature('hazardStripe') && (
+          <div className="cp-hazard shrink-0" aria-hidden="true" />
+        )}
         <div className="cp-sidebar__inner">
           <div className={cn(
             "cp-sidebar__brand",
@@ -546,7 +547,7 @@ function App() {
             "app-main custom-scrollbar",
             isPS5
               ? "pt-8 px-16 pb-12"
-              : isCyberpunk
+              : hasFeature('densePadding')
                 ? "pt-8 px-6 pb-36 md:pt-10 md:px-16 md:pb-12"
                 : "pt-6 px-6 pb-36 md:pt-10 md:px-16 md:pb-12"
           )}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -28,6 +28,7 @@ import LogoIcon from './components/ui/LogoIcon'
 import Atmosphere from './components/ui/Atmosphere'
 import HudBar from './components/ui/HudBar'
 import HudButton from './components/ui/HudButton'
+import FlatlinedScreen from './components/ui/FlatlinedScreen'
 import { useTheme } from './theme/ThemeContext'
 
 // Views
@@ -372,12 +373,8 @@ function App() {
 
   if (isOffline) {
     return (
-      <div className="min-h-screen ps5-bg text-zinc-100 font-ps5 flex flex-col items-center justify-center p-4 text-center">
-        <div className="max-w-lg p-12 bg-black/40 rounded-3xl border border-white/5">
-          <div className="text-7xl font-light text-zinc-400 mb-12 font-mono">:(</div>
-          <h1 className="text-2xl font-bold mb-4 text-zinc-300">{t("app.offline.title", "Payload Manager is not running...")}</h1>
-          <p className="text-lg text-zinc-400 leading-relaxed">{t("app.offline.message_1", "Please ensure you have loaded")} <strong>pldmgr.elf</strong> {t("app.offline.message_2", "on your PS5 before launching this application.")}</p>
-        </div>
+      <div className={cn('app-shell ps5-bg', `theme-${themeId}`)} data-theme={themeId}>
+        <FlatlinedScreen onRetry={() => window.location.reload()} />
       </div>
     )
   }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -456,7 +456,7 @@ function App() {
             <button
               onClick={() => setSidebarExpanded(!sidebarExpanded)}
               className={cn(
-                "cp-sidebar__toggle p-2.5 bg-white/5 hover:bg-ps-blue hover:text-white rounded-xl transition-all shrink-0",
+                "cp-sidebar__toggle p-2.5 bg-white/5 rounded-xl transition-all shrink-0",
                 sidebarExpanded && "mr-3"
               )}
               aria-label={sidebarExpanded ? "Collapse sidebar" : "Expand sidebar"}

--- a/frontend/src/components/ui/Atmosphere.jsx
+++ b/frontend/src/components/ui/Atmosphere.jsx
@@ -1,6 +1,7 @@
 /**
- * Cyberpunk atmosphere: red haze, code rain, grid — like Flatlined / pause menu.
- * Only visible when data-theme=cyberpunk (opacity via CSS).
+ * Atmosphere chrome: haze, code rain, grid.
+ * Mounted only when the active theme has feature `atmosphere`.
+ * Visuals come from [data-skin="…"] CSS (e.g. cyberpunk).
  */
 
 const COLS = 18

--- a/frontend/src/components/ui/Atmosphere.jsx
+++ b/frontend/src/components/ui/Atmosphere.jsx
@@ -1,0 +1,44 @@
+/**
+ * Cyberpunk atmosphere: red haze, code rain, grid — like Flatlined / pause menu.
+ * Only visible when data-theme=cyberpunk (opacity via CSS).
+ */
+
+const COLS = 18
+const ROWS = 24
+
+function makeColumn(seed) {
+  const lines = []
+  for (let i = 0; i < ROWS; i++) {
+    const n = ((seed * 17 + i * 31) % 1000) / 1000
+    lines.push(n.toFixed(4))
+  }
+  return lines.join('\n')
+}
+
+export default function Atmosphere() {
+  return (
+    <div className="cp-atm" aria-hidden="true">
+      <div className="cp-atm__haze" />
+      <div className="cp-atm__grid" />
+      <div className="cp-atm__vignette" />
+      <div className="cp-atm__scanlines" />
+
+      <div className="cp-atm__rain">
+        {Array.from({ length: COLS }, (_, i) => (
+          <pre
+            key={i}
+            className={`cp-atm__col cp-atm__col--${(i % 3) + 1}`}
+            style={{
+              left: `${(i / COLS) * 100}%`,
+              animationDelay: `${-(i * 0.45)}s`,
+              animationDuration: `${10 + (i % 5)}s`,
+            }}
+          >
+            {makeColumn(i + 3)}
+          </pre>
+        ))}
+      </div>
+      {/* Corner status chips intentionally omitted — they clipped page headers */}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/FlatlinedScreen.jsx
+++ b/frontend/src/components/ui/FlatlinedScreen.jsx
@@ -7,8 +7,8 @@ import HudButton from './HudButton'
 
 /**
  * Error / offline screen.
- * - classic: clean rounded error card (no CP death-menu chrome)
- * - cyberpunk: CP2077 "FLATLINED" death screen
+ * - flatlinedError off: clean rounded error card
+ * - flatlinedError on: "FLATLINED" death screen (CP2077-style chrome)
  *
  * @param {object} props
  * @param {() => void} [props.onRetry]
@@ -31,11 +31,11 @@ export default function FlatlinedScreen({
   showReload = true,
 }) {
   const { t } = useTranslation()
-  const { themeId } = useTheme()
-  const isCyber = themeId === 'cyberpunk'
+  const { hasFeature } = useTheme()
+  const useFlatlined = hasFeature('flatlinedError')
 
   const rain = useMemo(() => {
-    if (!isCyber) return []
+    if (!useFlatlined) return []
     const cols = []
     for (let i = 0; i < 18; i++) {
       const digits = Array.from({ length: 28 }, () =>
@@ -50,7 +50,7 @@ export default function FlatlinedScreen({
       })
     }
     return cols
-  }, [isCyber])
+  }, [useFlatlined])
 
   const deckId = useMemo(
     () => `0.${String(Math.floor(Math.random() * 99999)).padStart(5, '0')}`,
@@ -84,7 +84,7 @@ export default function FlatlinedScreen({
     ) : null
 
   /* ── Classic: clean PS-style error card ── */
-  if (!isCyber) {
+  if (!useFlatlined) {
     const classicTitle =
       title ?? t('app.offline.error_title', 'Something went wrong')
     return (

--- a/frontend/src/components/ui/FlatlinedScreen.jsx
+++ b/frontend/src/components/ui/FlatlinedScreen.jsx
@@ -1,0 +1,164 @@
+import React, { useMemo } from 'react'
+import { Skull, RefreshCw, AlertTriangle } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { cn } from '../../utils/helpers'
+import { useTheme } from '../../theme/ThemeContext'
+import HudButton from './HudButton'
+
+/**
+ * CP2077-style death / error screen ("FLATLINED").
+ *
+ * @param {object} props
+ * @param {() => void} [props.onRetry]
+ * @param {string} [props.title] — big FLATLINED heading (default)
+ * @param {string} [props.message] — primary status line
+ * @param {string} [props.detail] — secondary explanation (string or leave default offline copy)
+ * @param {string} [props.retryLabel]
+ * @param {string} [props.chipLabel] — top-left warn chip
+ * @param {boolean} [props.embedded] — fit inside a view (not full-viewport takeover)
+ * @param {boolean} [props.showReload] — secondary RELOAD INTERFACE row
+ */
+export default function FlatlinedScreen({
+  onRetry,
+  title,
+  message,
+  detail,
+  retryLabel,
+  chipLabel,
+  embedded = false,
+  showReload = true,
+}) {
+  const { t } = useTranslation()
+  const { themeId } = useTheme()
+  const isCyber = themeId === 'cyberpunk'
+
+  const rain = useMemo(() => {
+    const cols = []
+    for (let i = 0; i < 18; i++) {
+      const digits = Array.from({ length: 28 }, () =>
+        (Math.random() > 0.5 ? '1' : '0') + (Math.random() > 0.7 ? 'X' : '')
+      ).join('\n')
+      cols.push({
+        left: `${4 + i * 5.4}%`,
+        delay: `${(i * 0.37) % 4}s`,
+        duration: `${8 + (i % 5)}s`,
+        opacity: 0.12 + (i % 4) * 0.04,
+        text: digits,
+      })
+    }
+    return cols
+  }, [])
+
+  const deckId = useMemo(
+    () => `0.${String(Math.floor(Math.random() * 99999)).padStart(5, '0')}`,
+    []
+  )
+
+  const handleRetry = () => {
+    if (onRetry) onRetry()
+    else window.location.reload()
+  }
+
+  const flatTitle = title ?? t('app.offline.flatlined', 'FLATLINED')
+  const flatMessage =
+    message ?? t('app.offline.title', 'Payload Manager is not running...')
+  const flatRetry = retryLabel ?? t('app.offline.retry', 'RETRY CONNECTION')
+  const flatChip = chipLabel ?? t('app.offline.connection_lost', 'CONNECTION LOST')
+
+  return (
+    <div
+      className={cn(
+        'cp-flatlined',
+        isCyber && 'cp-flatlined--cyber',
+        embedded && 'cp-flatlined--embedded'
+      )}
+    >
+      <div className="cp-flatlined__rain" aria-hidden="true">
+        {rain.map((col, i) => (
+          <pre
+            key={i}
+            className="cp-flatlined__rain-col"
+            style={{
+              left: col.left,
+              animationDelay: col.delay,
+              animationDuration: col.duration,
+              opacity: col.opacity,
+            }}
+          >
+            {col.text}
+          </pre>
+        ))}
+      </div>
+
+      <div className="cp-flatlined__scan" aria-hidden="true" />
+      <div className="cp-flatlined__vignette" aria-hidden="true" />
+
+      <div className="cp-flatlined__top">
+        <div className="cp-flatlined__chip cp-flatlined__chip--warn">{flatChip}</div>
+        <div className="cp-flatlined__chip">
+          {t('app.offline.core_error', 'CORE CRITICAL ERROR AT POINT 0.0')}
+        </div>
+      </div>
+
+      <div className="cp-flatlined__panel">
+        <div className="cp-flatlined__brand">
+          <Skull className="cp-flatlined__skull" strokeWidth={1.25} />
+          <div className="cp-flatlined__titles">
+            <h1 className="cp-flatlined__title">{flatTitle}</h1>
+            <p className="cp-flatlined__deck">コーデック {deckId}</p>
+          </div>
+        </div>
+
+        <p className="cp-flatlined__msg">{flatMessage}</p>
+
+        {detail !== null && (
+          <p className="cp-flatlined__detail">
+            {detail !== undefined ? (
+              detail
+            ) : (
+              <>
+                {t('app.offline.message_1', 'Please ensure you have loaded')}{' '}
+                <strong>pldmgr.elf</strong>{' '}
+                {t(
+                  'app.offline.message_2',
+                  'on your PS5 before launching this application.'
+                )}
+              </>
+            )}
+          </p>
+        )}
+
+        <div className="cp-flatlined__menu">
+          <HudButton
+            onClick={handleRetry}
+            icon={RefreshCw}
+            variant="primary"
+            size="lg"
+            block
+            className="cp-btn--bar cp-flatlined__primary"
+          >
+            {flatRetry}
+          </HudButton>
+
+          {showReload && (
+            <button
+              type="button"
+              className="cp-flatlined__menu-item"
+              onClick={() => window.location.reload()}
+            >
+              {t('app.offline.reload', 'RELOAD INTERFACE')}
+            </button>
+          )}
+        </div>
+
+        <div className="cp-flatlined__foot">
+          <AlertTriangle className="w-3.5 h-3.5 shrink-0" />
+          <span>
+            {t('app.offline.fatal', 'FATAL SYSTEM ERROR')} X00302 · NRN_ERROR IN 0A93/
+            {deckId.slice(-4)}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/ui/FlatlinedScreen.jsx
+++ b/frontend/src/components/ui/FlatlinedScreen.jsx
@@ -1,22 +1,24 @@
 import React, { useMemo } from 'react'
-import { Skull, RefreshCw, AlertTriangle } from 'lucide-react'
+import { Skull, RefreshCw, AlertTriangle, AlertCircle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '../../utils/helpers'
 import { useTheme } from '../../theme/ThemeContext'
 import HudButton from './HudButton'
 
 /**
- * CP2077-style death / error screen ("FLATLINED").
+ * Error / offline screen.
+ * - classic: clean rounded error card (no CP death-menu chrome)
+ * - cyberpunk: CP2077 "FLATLINED" death screen
  *
  * @param {object} props
  * @param {() => void} [props.onRetry]
- * @param {string} [props.title] — big FLATLINED heading (default)
- * @param {string} [props.message] — primary status line
- * @param {string} [props.detail] — secondary explanation (string or leave default offline copy)
+ * @param {string} [props.title]
+ * @param {string} [props.message]
+ * @param {string} [props.detail]
  * @param {string} [props.retryLabel]
- * @param {string} [props.chipLabel] — top-left warn chip
- * @param {boolean} [props.embedded] — fit inside a view (not full-viewport takeover)
- * @param {boolean} [props.showReload] — secondary RELOAD INTERFACE row
+ * @param {string} [props.chipLabel]
+ * @param {boolean} [props.embedded]
+ * @param {boolean} [props.showReload]
  */
 export default function FlatlinedScreen({
   onRetry,
@@ -33,6 +35,7 @@ export default function FlatlinedScreen({
   const isCyber = themeId === 'cyberpunk'
 
   const rain = useMemo(() => {
+    if (!isCyber) return []
     const cols = []
     for (let i = 0; i < 18; i++) {
       const digits = Array.from({ length: 28 }, () =>
@@ -47,7 +50,7 @@ export default function FlatlinedScreen({
       })
     }
     return cols
-  }, [])
+  }, [isCyber])
 
   const deckId = useMemo(
     () => `0.${String(Math.floor(Math.random() * 99999)).padStart(5, '0')}`,
@@ -59,17 +62,90 @@ export default function FlatlinedScreen({
     else window.location.reload()
   }
 
-  const flatTitle = title ?? t('app.offline.flatlined', 'FLATLINED')
   const flatMessage =
     message ?? t('app.offline.title', 'Payload Manager is not running...')
   const flatRetry = retryLabel ?? t('app.offline.retry', 'RETRY CONNECTION')
   const flatChip = chipLabel ?? t('app.offline.connection_lost', 'CONNECTION LOST')
 
+  const detailBody =
+    detail !== null ? (
+      detail !== undefined ? (
+        detail
+      ) : (
+        <>
+          {t('app.offline.message_1', 'Please ensure you have loaded')}{' '}
+          <strong>pldmgr.elf</strong>{' '}
+          {t(
+            'app.offline.message_2',
+            'on your PS5 before launching this application.'
+          )}
+        </>
+      )
+    ) : null
+
+  /* ── Classic: clean PS-style error card ── */
+  if (!isCyber) {
+    const classicTitle =
+      title ?? t('app.offline.error_title', 'Something went wrong')
+    return (
+      <div
+        className={cn(
+          'cp-flatlined cp-flatlined--classic',
+          embedded && 'cp-flatlined--embedded'
+        )}
+      >
+        <div className="cp-flatlined__panel">
+          <div className="cp-flatlined__brand">
+            <div className="cp-flatlined__icon-wrap">
+              <AlertCircle className="cp-flatlined__skull" strokeWidth={1.75} />
+            </div>
+            <div className="cp-flatlined__titles">
+              <h1 className="cp-flatlined__title">{classicTitle}</h1>
+              {flatChip && (
+                <p className="cp-flatlined__deck">{flatChip}</p>
+              )}
+            </div>
+          </div>
+
+          <p className="cp-flatlined__msg">{flatMessage}</p>
+
+          {detailBody != null && (
+            <p className="cp-flatlined__detail">{detailBody}</p>
+          )}
+
+          <div className="cp-flatlined__menu">
+            <button
+              type="button"
+              onClick={handleRetry}
+              className="cp-flatlined__classic-btn"
+            >
+              <RefreshCw className="w-5 h-5" />
+              {flatRetry}
+            </button>
+
+            {showReload && (
+              <button
+                type="button"
+                className="cp-flatlined__menu-item"
+                onClick={() => window.location.reload()}
+              >
+                {t('app.offline.reload', 'Reload page')}
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  /* ── Cyberpunk: FLATLINED death screen ── */
+  const flatTitle = title ?? t('app.offline.flatlined', 'FLATLINED')
+
   return (
     <div
       className={cn(
         'cp-flatlined',
-        isCyber && 'cp-flatlined--cyber',
+        'cp-flatlined--cyber',
         embedded && 'cp-flatlined--embedded'
       )}
     >
@@ -111,21 +187,8 @@ export default function FlatlinedScreen({
 
         <p className="cp-flatlined__msg">{flatMessage}</p>
 
-        {detail !== null && (
-          <p className="cp-flatlined__detail">
-            {detail !== undefined ? (
-              detail
-            ) : (
-              <>
-                {t('app.offline.message_1', 'Please ensure you have loaded')}{' '}
-                <strong>pldmgr.elf</strong>{' '}
-                {t(
-                  'app.offline.message_2',
-                  'on your PS5 before launching this application.'
-                )}
-              </>
-            )}
-          </p>
+        {detailBody != null && (
+          <p className="cp-flatlined__detail">{detailBody}</p>
         )}
 
         <div className="cp-flatlined__menu">

--- a/frontend/src/components/ui/HudBar.jsx
+++ b/frontend/src/components/ui/HudBar.jsx
@@ -1,0 +1,28 @@
+/**
+ * Top HUD strip — pause menu style (level / street cred / eurodollars vibe).
+ */
+export default function HudBar({ version, ip }) {
+  return (
+    <header className="cp-hudbar" aria-hidden="false">
+      <div className="cp-hudbar__left">
+        <span className="cp-hudbar__stat">
+          <span className="cp-hudbar__num">PLD</span>
+          <span className="cp-hudbar__label">MGR</span>
+        </span>
+        <span className="cp-hudbar__sep" />
+        <span className="cp-hudbar__stat cp-hudbar__stat--cyan">
+          <span className="cp-hudbar__num">LINK</span>
+          <span className="cp-hudbar__label">ACTIVE</span>
+        </span>
+      </div>
+      <div className="cp-hudbar__mid">
+        <span className="cp-hudbar__protocol">PROTOCOL 6920-A44 // PAYLOAD MANAGER</span>
+      </div>
+      <div className="cp-hudbar__right">
+        <span className="cp-hudbar__meta">{version || '—'}</span>
+        <span className="cp-hudbar__sep" />
+        <span className="cp-hudbar__meta cp-hudbar__meta--cyan">{ip || '0.0.0.0'}</span>
+      </div>
+    </header>
+  )
+}

--- a/frontend/src/components/ui/HudButton.jsx
+++ b/frontend/src/components/ui/HudButton.jsx
@@ -3,8 +3,7 @@ import { cn } from '../../utils/helpers'
 import { useTheme } from '../../theme/ThemeContext'
 
 /**
- * Action button — Cyberpunk 2077 menu bar style when cyberpunk theme is active.
- * Classic falls back to original rounded pills so dual themes stay isolated.
+ * Action button — HUD bar style when theme has `hudControls`, else classic pills.
  *
  * variants: primary | secondary | danger | dangerSoft | success | ghost
  * sizes: sm | md | lg
@@ -49,11 +48,11 @@ export default function HudButton({
   type = 'button',
   ...props
 }) {
-  const { themeId } = useTheme()
-  const isCyber = themeId === 'cyberpunk'
+  const { hasFeature } = useTheme()
+  const hudControls = hasFeature('hudControls')
   const iconSpin = Icon && (Icon.displayName === 'Loader2' || Icon.name === 'Loader2')
 
-  if (!isCyber) {
+  if (!hudControls) {
     return (
       <button
         type={type}

--- a/frontend/src/components/ui/HudButton.jsx
+++ b/frontend/src/components/ui/HudButton.jsx
@@ -1,0 +1,123 @@
+import React from 'react'
+import { cn } from '../../utils/helpers'
+import { useTheme } from '../../theme/ThemeContext'
+
+/**
+ * Action button — Cyberpunk 2077 menu bar style when cyberpunk theme is active.
+ * Classic falls back to original rounded pills so dual themes stay isolated.
+ *
+ * variants: primary | secondary | danger | dangerSoft | success | ghost
+ * sizes: sm | md | lg
+ */
+const CLASSIC = {
+  primary:
+    'bg-ps-blue hover:bg-ps-blue/80 text-white rounded-2xl font-bold border border-transparent',
+  secondary:
+    'bg-white/5 hover:bg-white/10 text-white rounded-2xl font-bold border border-white/10',
+  danger:
+    'bg-red-600 hover:bg-red-500 text-white rounded-2xl font-bold border border-transparent',
+  dangerSoft:
+    'bg-red-500/10 hover:bg-red-500 text-red-500 hover:text-white rounded-xl font-bold border border-red-500/10',
+  success:
+    'bg-emerald-600 hover:bg-emerald-500 text-white rounded-2xl font-bold border border-transparent',
+  ghost:
+    'bg-transparent hover:bg-white/5 text-zinc-300 hover:text-white rounded-2xl font-bold border border-white/10 border-dashed',
+}
+
+const SIZE_CLASSIC = {
+  sm: 'px-4 py-2 text-sm space-x-2',
+  md: 'px-6 py-3 text-base space-x-3',
+  lg: 'px-8 py-5 text-lg space-x-3',
+}
+
+const SIZE_ICON = {
+  sm: 'w-4 h-4',
+  md: 'w-5 h-5',
+  lg: 'w-6 h-6',
+}
+
+export default function HudButton({
+  children,
+  icon: Icon,
+  endIcon: EndIcon,
+  variant = 'primary',
+  size = 'md',
+  block = false,
+  /** When true, children are not wrapped in .cp-btn__label (for complex rows) */
+  raw = false,
+  className,
+  type = 'button',
+  ...props
+}) {
+  const { themeId } = useTheme()
+  const isCyber = themeId === 'cyberpunk'
+  const iconSpin = Icon && (Icon.displayName === 'Loader2' || Icon.name === 'Loader2')
+
+  if (!isCyber) {
+    return (
+      <button
+        type={type}
+        className={cn(
+          'inline-flex items-center justify-center transition-all transform active:scale-95 disabled:opacity-40 disabled:pointer-events-none',
+          CLASSIC[variant] || CLASSIC.primary,
+          SIZE_CLASSIC[size] || SIZE_CLASSIC.md,
+          block && 'w-full',
+          EndIcon && 'justify-between',
+          className
+        )}
+        {...props}
+      >
+        <span className="inline-flex items-center gap-3 min-w-0">
+          {Icon && (
+            <Icon
+              className={cn(
+                SIZE_ICON[size] || SIZE_ICON.md,
+                'shrink-0',
+                iconSpin && 'animate-spin'
+              )}
+            />
+          )}
+          {children != null && children !== false && (
+            raw ? children : <span className="min-w-0">{children}</span>
+          )}
+        </span>
+        {EndIcon && <EndIcon className={cn(SIZE_ICON[size] || SIZE_ICON.md, 'shrink-0 ml-3')} />}
+      </button>
+    )
+  }
+
+  return (
+    <button
+      type={type}
+      className={cn(
+        'cp-btn',
+        `cp-btn--${variant}`,
+        size !== 'md' && `cp-btn--${size}`,
+        block && 'cp-btn--block',
+        EndIcon && 'cp-btn--with-end',
+        className
+      )}
+      {...props}
+    >
+      {Icon && (
+        <Icon
+          className={cn(
+            'cp-btn__icon',
+            SIZE_ICON[size] || SIZE_ICON.md,
+            iconSpin && 'animate-spin'
+          )}
+        />
+      )}
+      {children != null && children !== false && children !== '' && (
+        raw ? (
+          <span className="cp-btn__body min-w-0 flex-1 text-left">{children}</span>
+        ) : (
+          <span className="cp-btn__label">{children}</span>
+        )
+      )}
+      {EndIcon && (
+        <EndIcon className={cn('cp-btn__icon cp-btn__end', SIZE_ICON[size] || SIZE_ICON.md)} />
+      )}
+    </button>
+  )
+}

--- a/frontend/src/components/ui/NavButton.jsx
+++ b/frontend/src/components/ui/NavButton.jsx
@@ -3,35 +3,47 @@ import { cn, isPS5 } from '../../utils/helpers'
 
 const NavButton = ({ active, onClick, icon: Icon, label, mobileLabel, className, sidebar, sidebarExpanded, showSeparator, isDonate }) => {
   return (
-    <div className="flex items-center flex-1 md:flex-none min-w-max">
+    <div
+      className={cn(
+        "flex items-center",
+        // Sidebar: never grow — stacked items only. Mobile bar: share width.
+        sidebar ? "w-full shrink-0" : "flex-1 md:flex-none"
+      )}
+    >
       {showSeparator && <div className="w-px h-6 bg-white/10 md:hidden" />}
       <button
         onClick={onClick}
         className={cn(
-          "flex items-center transition-all border group relative outline-none",
+          "flex items-center transition-all border group relative outline-none cp-nav-item",
           sidebar
-            ? cn("w-full p-4 mb-2 rounded-2xl border-none", sidebarExpanded ? "justify-start space-x-4" : "justify-center")
-            : (isPS5 ? "flex-row space-x-3 px-6 py-3 rounded-2xl" : "flex-col md:flex-row md:space-x-3 px-4 md:px-6 py-2 md:py-3 rounded-2xl border-none flex-1 md:flex-none"),
-          active
-            ? (sidebar
-              ? (isDonate ? "bg-red-600 text-white shadow-[0_0_20px_rgba(220,38,38,0.3)]" : "bg-ps-blue text-white shadow-[0_0_20px_rgba(0,112,209,0.3)]")
-              : (isDonate ? "text-red-500" : "text-ps-blue font-black"))
-            : (isDonate ? "text-red-500/60" : "bg-transparent text-zinc-400 hover:text-white"),
+            ? cn(
+                "w-full shrink-0",
+                sidebarExpanded ? "justify-start" : "justify-center"
+              )
+            : (isPS5 ? "flex-row space-x-3 px-6 py-3" : "flex-col md:flex-row md:space-x-3 px-4 md:px-6 py-2 md:py-3 border-none flex-1 md:flex-none"),
+          active && "is-active",
+          // Donate stays red-tinted, but still uses the same frame shape when active
+          isDonate && !active && "cp-nav-donate",
+          isDonate && active && "cp-nav-donate is-active",
           className
         )}
       >
         <Icon className={cn(
-          "w-6 h-6 shrink-0 group-hover:scale-110 transition-transform",
-          active ? (sidebar ? "text-current" : (isDonate ? "text-red-500" : "text-ps-blue")) : (isDonate ? "text-red-500" : "")
+          "w-5 h-5 shrink-0 transition-colors",
+          active ? "text-current" : ""
         )} />
         <span className={cn(
-          "uppercase tracking-tighter transition-all duration-300 whitespace-nowrap overflow-hidden",
+          "uppercase tracking-widest transition-all duration-300 whitespace-nowrap overflow-hidden font-bold",
           sidebar
-            ? (sidebarExpanded ? "opacity-100 w-auto font-bold text-sm" : "opacity-0 w-0")
-            : (isPS5 ? "text-sm font-bold" : "text-[10px] md:text-sm")
+            ? (sidebarExpanded ? "opacity-100 w-auto text-sm" : "opacity-0 w-0")
+            : (isPS5 ? "text-sm" : "text-[10px] md:text-sm")
         )}>
           <span className={cn((isPS5 || sidebar) ? "inline" : "hidden md:inline")}>{label}</span>
-          {!isPS5 && !sidebar && <span className={cn("inline md:hidden", active ? (isDonate ? "text-red-500" : "text-ps-blue") : "font-medium text-zinc-500")}>{mobileLabel}</span>}
+          {!isPS5 && !sidebar && (
+            <span className={cn("inline md:hidden", active ? "font-black" : "font-medium opacity-70")}>
+              {mobileLabel}
+            </span>
+          )}
         </span>
       </button>
     </div>

--- a/frontend/src/components/ui/NavButton.jsx
+++ b/frontend/src/components/ui/NavButton.jsx
@@ -1,50 +1,61 @@
 import React from 'react'
 import { cn, isPS5 } from '../../utils/helpers'
 
+/**
+ * Shared nav control for sidebar + mobile bar.
+ * Layout (padding, gap, radius) comes from theme CSS via .cp-nav-item so
+ * Classic and Cyberpunk can look completely different without fighting
+ * Tailwind utilities here.
+ */
 const NavButton = ({ active, onClick, icon: Icon, label, mobileLabel, className, sidebar, sidebarExpanded, showSeparator, isDonate }) => {
   return (
     <div
       className={cn(
-        "flex items-center",
-        // Sidebar: never grow — stacked items only. Mobile bar: share width.
-        sidebar ? "w-full shrink-0" : "flex-1 md:flex-none"
+        'flex items-center',
+        sidebar ? 'w-full shrink-0' : 'flex-1 md:flex-none'
       )}
     >
       {showSeparator && <div className="w-px h-6 bg-white/10 md:hidden" />}
       <button
+        type="button"
         onClick={onClick}
         className={cn(
-          "flex items-center transition-all border group relative outline-none cp-nav-item",
+          'flex items-center transition-all border group relative outline-none cp-nav-item',
           sidebar
             ? cn(
-                "w-full shrink-0",
-                sidebarExpanded ? "justify-start" : "justify-center"
+                'w-full shrink-0',
+                sidebarExpanded ? 'justify-start' : 'justify-center'
               )
-            : (isPS5 ? "flex-row space-x-3 px-6 py-3" : "flex-col md:flex-row md:space-x-3 px-4 md:px-6 py-2 md:py-3 border-none flex-1 md:flex-none"),
-          active && "is-active",
-          // Donate stays red-tinted, but still uses the same frame shape when active
-          isDonate && !active && "cp-nav-donate",
-          isDonate && active && "cp-nav-donate is-active",
+            : (isPS5
+              ? 'flex-row px-6 py-3'
+              : 'flex-col md:flex-row px-4 md:px-6 py-2 md:py-3 border-none flex-1 md:flex-none'),
+          active && 'is-active',
+          isDonate && 'cp-nav-donate',
           className
         )}
       >
-        <Icon className={cn(
-          "w-5 h-5 shrink-0 transition-colors",
-          active ? "text-current" : ""
-        )} />
-        <span className={cn(
-          "uppercase tracking-widest transition-all duration-300 whitespace-nowrap overflow-hidden font-bold",
-          sidebar
-            ? (sidebarExpanded ? "opacity-100 w-auto text-sm" : "opacity-0 w-0")
-            : (isPS5 ? "text-sm" : "text-[10px] md:text-sm")
-        )}>
-          <span className={cn((isPS5 || sidebar) ? "inline" : "hidden md:inline")}>{label}</span>
-          {!isPS5 && !sidebar && (
-            <span className={cn("inline md:hidden", active ? "font-black" : "font-medium opacity-70")}>
-              {mobileLabel}
-            </span>
+        <Icon
+          className={cn(
+            'shrink-0 transition-colors',
+            sidebar ? 'w-6 h-6' : 'w-5 h-5'
           )}
-        </span>
+        />
+        {/* Keep label mounted for expanded sidebar + mobile; fully omit width when collapsed */}
+        {(!sidebar || sidebarExpanded) && (
+          <span
+            className={cn(
+              'uppercase transition-all duration-300 whitespace-nowrap overflow-hidden font-bold',
+              sidebar ? 'opacity-100 w-auto text-sm' : (isPS5 ? 'text-sm' : 'text-[10px] md:text-sm')
+            )}
+          >
+            <span className={cn((isPS5 || sidebar) ? 'inline' : 'hidden md:inline')}>{label}</span>
+            {!isPS5 && !sidebar && (
+              <span className={cn('inline md:hidden', active ? 'font-black' : 'font-medium opacity-70')}>
+                {mobileLabel}
+              </span>
+            )}
+          </span>
+        )}
       </button>
     </div>
   )

--- a/frontend/src/components/ui/PayloadButton.jsx
+++ b/frontend/src/components/ui/PayloadButton.jsx
@@ -7,7 +7,7 @@ const PayloadButton = ({ path, onClick, isLoading, sourceName, version }) => {
     <button
       onClick={onClick}
       disabled={isLoading}
-      className="group glass-card p-6 rounded-ps-xl flex flex-col border border-white/5 hover:border-ps-blue hover:bg-ps-blue/5 transition-all text-left relative overflow-hidden"
+      className="group glass-card p-6 rounded-ps-xl flex flex-col border border-white/5 hover:border-ps-blue hover:bg-ps-blue/5 transition-all text-left relative"
     >
       <div className="flex items-start justify-between w-full z-10">
         <PayloadName path={path} version={version} className="text-white text-xl" stacked />

--- a/frontend/src/components/ui/Toast.jsx
+++ b/frontend/src/components/ui/Toast.jsx
@@ -10,7 +10,7 @@ const Toast = ({ message, type = 'success', onClose }) => {
 
   return (
     <div className={cn(
-      "fixed top-8 right-8 z-[1000] flex items-center space-x-4 p-5 rounded-2xl border shadow-2xl animate-in slide-in-from-right duration-300 pointer-events-auto",
+      "cp-clip fixed top-8 right-8 z-[1000] flex items-center space-x-4 p-5 rounded-2xl border shadow-2xl animate-in slide-in-from-right duration-300 pointer-events-auto",
       type === 'success' ? "bg-emerald-950/90 border-emerald-500/50 text-emerald-400" : "bg-red-950/90 border-red-500/50 text-red-400"
     )}>
       {type === 'success' ? <CheckCircle2 className="w-6 h-6" /> : <AlertTriangle className="w-6 h-6" />}

--- a/frontend/src/components/ui/ToggleSwitch.jsx
+++ b/frontend/src/components/ui/ToggleSwitch.jsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { cn } from '../../utils/helpers'
+import { useTheme } from '../../theme/ThemeContext'
+
+/**
+ * Theme-aware boolean control.
+ * Cyberpunk: segmented OFF | ON bar (game settings style).
+ * Classic: pill switch.
+ */
+export default function ToggleSwitch({ on = false, onChange, className, labels = { off: 'OFF', on: 'ON' } }) {
+  const { themeId } = useTheme()
+  const isCyber = themeId === 'cyberpunk'
+
+  if (!isCyber) {
+    return (
+      <button
+        type="button"
+        role="switch"
+        aria-checked={!!on}
+        onClick={() => onChange?.(!on)}
+        className={cn(
+          'w-14 h-7 md:w-20 md:h-10 rounded-full transition-all relative p-1 md:p-1.5',
+          on ? 'bg-ps-blue' : 'bg-white/10',
+          className
+        )}
+      >
+        <div
+          className={cn(
+            'w-5 h-5 md:w-7 md:h-7 bg-white rounded-full transition-all',
+            on ? 'translate-x-7 md:translate-x-10' : 'translate-x-0'
+          )}
+        />
+      </button>
+    )
+  }
+
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={!!on}
+      onClick={() => onChange?.(!on)}
+      className={cn('cp-toggle', on ? 'is-on' : 'is-off', className)}
+    >
+      <span className={cn('cp-toggle__seg cp-toggle__seg--off', !on && 'is-selected')}>
+        {labels.off}
+      </span>
+      <span className={cn('cp-toggle__seg cp-toggle__seg--on', on && 'is-selected')}>
+        {labels.on}
+      </span>
+    </button>
+  )
+}

--- a/frontend/src/components/ui/ToggleSwitch.jsx
+++ b/frontend/src/components/ui/ToggleSwitch.jsx
@@ -4,14 +4,14 @@ import { useTheme } from '../../theme/ThemeContext'
 
 /**
  * Theme-aware boolean control.
- * Cyberpunk: segmented OFF | ON bar (game settings style).
- * Classic: pill switch.
+ * hudControls on: segmented OFF | ON bar (game settings style).
+ * hudControls off: pill switch.
  */
 export default function ToggleSwitch({ on = false, onChange, className, labels = { off: 'OFF', on: 'ON' } }) {
-  const { themeId } = useTheme()
-  const isCyber = themeId === 'cyberpunk'
+  const { hasFeature } = useTheme()
+  const hudControls = hasFeature('hudControls')
 
-  if (!isCyber) {
+  if (!hudControls) {
     return (
       <button
         type="button"

--- a/frontend/src/components/views/ActiveProcessesView.jsx
+++ b/frontend/src/components/views/ActiveProcessesView.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react'
 import { Cpu, RefreshCw, XCircle, Search, AlertTriangle, Activity, Loader2, Info, Trash2 } from 'lucide-react'
 import { useTranslation, Trans } from 'react-i18next'
 import { cn, isPS5 } from '../../utils/helpers'
+import ToggleSwitch from '../ui/ToggleSwitch'
 
 const ActiveProcessesView = ({ ip, addToast, showConfirm }) => {
   const { t } = useTranslation()
@@ -83,27 +84,14 @@ const ActiveProcessesView = ({ ip, addToast, showConfirm }) => {
     <div className="space-y-12">
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-8">
         <h2 className="text-4xl font-extrabold text-white tracking-tight">
-          {t("active_processes.title_active", "Active")} <span className="text-ps-blue">{t("active_processes.title_processes", "Processes")}</span>
+          {t("active_processes.title_active", "Active")} <span className="cp-title-accent">{t("active_processes.title_processes", "Processes")}</span>
         </h2>
         <div className="flex items-center space-x-4">
-          <label className="flex items-center space-x-3 cursor-pointer group">
-            <div className="relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-ps-blue focus:ring-offset-2 focus:ring-offset-black bg-white/10 group-hover:bg-white/20">
-              <input
-                type="checkbox"
-                className="sr-only"
-                checked={showAll}
-                onChange={(e) => setShowAll(e.target.checked)}
-              />
-              <span
-                className={cn(
-                  "inline-block h-4 w-4 transform rounded-full bg-white transition-transform",
-                  showAll ? "translate-x-6 bg-ps-blue" : "translate-x-1"
-                )}
-              />
-            </div>
+          <label className="flex items-center space-x-3 cursor-pointer group gap-3">
             <span className="text-sm font-bold text-zinc-300 select-none cursor-pointer">
               {t("active_processes.show_all", "Show All System Processes")}
             </span>
+            <ToggleSwitch on={showAll} onChange={setShowAll} />
           </label>
         </div>
       </div>

--- a/frontend/src/components/views/ActiveProcessesView.jsx
+++ b/frontend/src/components/views/ActiveProcessesView.jsx
@@ -1,13 +1,16 @@
 import React, { useState, useEffect, useMemo } from 'react'
-import { Cpu, Search, Loader2, Info, Trash2 } from 'lucide-react'
+import { Cpu, Search, Loader2, Info, Trash2, AlertTriangle } from 'lucide-react'
 import { useTranslation, Trans } from 'react-i18next'
 import { cn, isPS5 } from '../../utils/helpers'
 import ToggleSwitch from '../ui/ToggleSwitch'
 import HudButton from '../ui/HudButton'
 import FlatlinedScreen from '../ui/FlatlinedScreen'
+import { useTheme } from '../../theme/ThemeContext'
 
 const ActiveProcessesView = ({ ip, addToast, showConfirm }) => {
   const { t } = useTranslation()
+  const { themeId } = useTheme()
+  const isCyber = themeId === 'cyberpunk'
   const [processes, setProcesses] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
@@ -116,18 +119,35 @@ const ActiveProcessesView = ({ ip, addToast, showConfirm }) => {
             <p className="label-caps animate-pulse text-zinc-500">{t("active_processes.fetching", "Fetching process list...")}</p>
           </div>
         ) : error ? (
-          <FlatlinedScreen
-            embedded
-            showReload={false}
-            onRetry={() => fetchProcesses()}
-            chipLabel={t("active_processes.error_chip", "PROCESS SCAN FAILED")}
-            message={t("active_processes.error_loading", "Failed to load processes")}
-            detail={t(
-              "active_processes.error_detail",
-              "Could not read the process list from the console. The daemon may be busy, offline, or the endpoint timed out."
-            )}
-            retryLabel={t("active_processes.retry", "RETRY SCAN")}
-          />
+          isCyber ? (
+            <FlatlinedScreen
+              embedded
+              showReload={false}
+              onRetry={() => fetchProcesses()}
+              chipLabel={t("active_processes.error_chip", "PROCESS SCAN FAILED")}
+              message={t("active_processes.error_loading", "Failed to load processes")}
+              detail={t(
+                "active_processes.error_detail",
+                "Could not read the process list from the console. The daemon may be busy, offline, or the endpoint timed out."
+              )}
+              retryLabel={t("active_processes.retry", "RETRY SCAN")}
+            />
+          ) : (
+            /* Original classic error panel (pre-FLATLINED) */
+            <div className="py-12 bg-red-500/10 border border-red-500/20 rounded-2xl flex flex-col items-center justify-center space-y-4">
+              <AlertTriangle className="w-10 h-10 text-red-500" />
+              <p className="text-red-400 font-bold">
+                {t("active_processes.error_loading", "Failed to load processes")}
+              </p>
+              <button
+                type="button"
+                onClick={() => fetchProcesses()}
+                className="px-6 py-2 bg-red-500 hover:bg-red-400 text-white rounded-xl font-bold transition-colors"
+              >
+                {t("active_processes.retry", "Retry")}
+              </button>
+            </div>
+          )
         ) : filteredProcesses.length === 0 ? (
           <div className="py-20 flex flex-col items-center justify-center space-y-6 bg-white/[0.02] border-2 border-dashed border-white/5 rounded-2xl">
             <Cpu className="w-12 h-12 text-zinc-600" />

--- a/frontend/src/components/views/ActiveProcessesView.jsx
+++ b/frontend/src/components/views/ActiveProcessesView.jsx
@@ -9,8 +9,8 @@ import { useTheme } from '../../theme/ThemeContext'
 
 const ActiveProcessesView = ({ ip, addToast, showConfirm }) => {
   const { t } = useTranslation()
-  const { themeId } = useTheme()
-  const isCyber = themeId === 'cyberpunk'
+  const { hasFeature } = useTheme()
+  const useFlatlined = hasFeature('flatlinedError')
   const [processes, setProcesses] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
@@ -119,7 +119,7 @@ const ActiveProcessesView = ({ ip, addToast, showConfirm }) => {
             <p className="label-caps animate-pulse text-zinc-500">{t("active_processes.fetching", "Fetching process list...")}</p>
           </div>
         ) : error ? (
-          isCyber ? (
+          useFlatlined ? (
             <FlatlinedScreen
               embedded
               showReload={false}
@@ -133,7 +133,7 @@ const ActiveProcessesView = ({ ip, addToast, showConfirm }) => {
               retryLabel={t("active_processes.retry", "RETRY SCAN")}
             />
           ) : (
-            /* Original classic error panel (pre-FLATLINED) */
+            /* Classic error panel when flatlinedError is off */
             <div className="py-12 bg-red-500/10 border border-red-500/20 rounded-2xl flex flex-col items-center justify-center space-y-4">
               <AlertTriangle className="w-10 h-10 text-red-500" />
               <p className="text-red-400 font-bold">

--- a/frontend/src/components/views/ActiveProcessesView.jsx
+++ b/frontend/src/components/views/ActiveProcessesView.jsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect, useMemo } from 'react'
-import { Cpu, RefreshCw, XCircle, Search, AlertTriangle, Activity, Loader2, Info, Trash2 } from 'lucide-react'
+import { Cpu, Search, Loader2, Info, Trash2 } from 'lucide-react'
 import { useTranslation, Trans } from 'react-i18next'
 import { cn, isPS5 } from '../../utils/helpers'
 import ToggleSwitch from '../ui/ToggleSwitch'
 import HudButton from '../ui/HudButton'
+import FlatlinedScreen from '../ui/FlatlinedScreen'
 
 const ActiveProcessesView = ({ ip, addToast, showConfirm }) => {
   const { t } = useTranslation()
@@ -115,13 +116,18 @@ const ActiveProcessesView = ({ ip, addToast, showConfirm }) => {
             <p className="label-caps animate-pulse text-zinc-500">{t("active_processes.fetching", "Fetching process list...")}</p>
           </div>
         ) : error ? (
-          <div className="py-12 bg-red-500/10 border border-red-500/20 rounded-2xl flex flex-col items-center justify-center space-y-4">
-            <AlertTriangle className="w-10 h-10 text-red-500" />
-            <p className="text-red-400 font-bold">{t("active_processes.error_loading", "Failed to load processes")}</p>
-            <HudButton onClick={fetchProcesses} variant="danger" size="sm">
-              {t("active_processes.retry", "Retry")}
-            </HudButton>
-          </div>
+          <FlatlinedScreen
+            embedded
+            showReload={false}
+            onRetry={() => fetchProcesses()}
+            chipLabel={t("active_processes.error_chip", "PROCESS SCAN FAILED")}
+            message={t("active_processes.error_loading", "Failed to load processes")}
+            detail={t(
+              "active_processes.error_detail",
+              "Could not read the process list from the console. The daemon may be busy, offline, or the endpoint timed out."
+            )}
+            retryLabel={t("active_processes.retry", "RETRY SCAN")}
+          />
         ) : filteredProcesses.length === 0 ? (
           <div className="py-20 flex flex-col items-center justify-center space-y-6 bg-white/[0.02] border-2 border-dashed border-white/5 rounded-2xl">
             <Cpu className="w-12 h-12 text-zinc-600" />

--- a/frontend/src/components/views/ActiveProcessesView.jsx
+++ b/frontend/src/components/views/ActiveProcessesView.jsx
@@ -3,6 +3,7 @@ import { Cpu, RefreshCw, XCircle, Search, AlertTriangle, Activity, Loader2, Info
 import { useTranslation, Trans } from 'react-i18next'
 import { cn, isPS5 } from '../../utils/helpers'
 import ToggleSwitch from '../ui/ToggleSwitch'
+import HudButton from '../ui/HudButton'
 
 const ActiveProcessesView = ({ ip, addToast, showConfirm }) => {
   const { t } = useTranslation()
@@ -117,9 +118,9 @@ const ActiveProcessesView = ({ ip, addToast, showConfirm }) => {
           <div className="py-12 bg-red-500/10 border border-red-500/20 rounded-2xl flex flex-col items-center justify-center space-y-4">
             <AlertTriangle className="w-10 h-10 text-red-500" />
             <p className="text-red-400 font-bold">{t("active_processes.error_loading", "Failed to load processes")}</p>
-            <button onClick={fetchProcesses} className="px-6 py-2 bg-red-500 hover:bg-red-400 text-white rounded-xl font-bold transition-colors">
+            <HudButton onClick={fetchProcesses} variant="danger" size="sm">
               {t("active_processes.retry", "Retry")}
-            </button>
+            </HudButton>
           </div>
         ) : filteredProcesses.length === 0 ? (
           <div className="py-20 flex flex-col items-center justify-center space-y-6 bg-white/[0.02] border-2 border-dashed border-white/5 rounded-2xl">
@@ -149,15 +150,17 @@ const ActiveProcessesView = ({ ip, addToast, showConfirm }) => {
                       </div>
                     </div>
                   </div>
-                  <button
+                  <HudButton
                     onClick={() => handleKill(p)}
                     disabled={critical}
-                    className="px-4 py-2 bg-red-500/10 hover:bg-red-500 text-red-500 hover:text-white rounded-xl font-bold text-sm transition-all disabled:opacity-30 disabled:cursor-not-allowed group-hover:opacity-100 opacity-50 flex items-center space-x-2"
+                    icon={Trash2}
+                    variant="dangerSoft"
+                    size="sm"
+                    className="opacity-50 group-hover:opacity-100"
                     title={critical ? t("active_processes.cannot_kill_tooltip", "Cannot kill critical process") : t("active_processes.kill_button", "Kill")}
                   >
-                    <Trash2 className="w-4 h-4" />
                     <span className="hidden sm:inline">{t("active_processes.kill_button", "Kill")}</span>
-                  </button>
+                  </HudButton>
                 </div>
               )
             })}

--- a/frontend/src/components/views/AutoloadOverlay.jsx
+++ b/frontend/src/components/views/AutoloadOverlay.jsx
@@ -3,6 +3,7 @@ import { CheckCircle2, AlertTriangle, Loader2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '../../utils/helpers'
 import PayloadName from '../ui/PayloadName'
+import HudButton from '../ui/HudButton'
 
 const AutoloadOverlay = ({ status, onCancel, onFinish, isPS5 }) => {
   const { t } = useTranslation()
@@ -133,20 +134,13 @@ const AutoloadOverlay = ({ status, onCancel, onFinish, isPS5 }) => {
           {/* Action Buttons */}
           <div className="w-full pt-4">
             {isDone ? (
-              <button
-                onClick={onFinish}
-                className="w-full py-8 bg-ps-blue text-black text-3xl font-extrabold rounded-xl hover:bg-ps-yellow transition-all transform active:scale-95 shadow-[0_0_30px_rgba(0,240,255,0.25)]"
-              >
+              <HudButton onClick={onFinish} variant="primary" size="lg" block className="cp-btn--bar !min-h-[4.5rem] !text-xl">
                 {t("autoload_overlay.return_btn", "Return to Dashboard")}
-              </button>
+              </HudButton>
             ) : isCountdown ? (
-              <button
-                onClick={onCancel}
-                autoFocus
-                className="w-full py-8 bg-white/10 text-white border border-white/10 text-3xl font-black uppercase rounded-3xl hover:bg-red-600 hover:border-red-600 transition-all transform active:scale-95"
-              >
+              <HudButton onClick={onCancel} autoFocus variant="danger" size="lg" block className="cp-btn--bar !min-h-[4.5rem] !text-xl">
                 {t("autoload_overlay.abort_btn", "Abort Autoload")}
-              </button>
+              </HudButton>
             ) : (
               <div className="h-[92px] w-full flex items-center justify-center">
                 <div className="flex space-x-2">

--- a/frontend/src/components/views/AutoloadOverlay.jsx
+++ b/frontend/src/components/views/AutoloadOverlay.jsx
@@ -135,7 +135,7 @@ const AutoloadOverlay = ({ status, onCancel, onFinish, isPS5 }) => {
             {isDone ? (
               <button
                 onClick={onFinish}
-                className="w-full py-8 bg-ps-blue text-white text-3xl font-extrabold rounded-3xl hover:bg-[#007acc] transition-all transform active:scale-95 shadow-[0_0_30px_rgba(0,149,255,0.2)]"
+                className="w-full py-8 bg-ps-blue text-black text-3xl font-extrabold rounded-xl hover:bg-ps-yellow transition-all transform active:scale-95 shadow-[0_0_30px_rgba(0,240,255,0.25)]"
               >
                 {t("autoload_overlay.return_btn", "Return to Dashboard")}
               </button>

--- a/frontend/src/components/views/AutoloadOverlay.jsx
+++ b/frontend/src/components/views/AutoloadOverlay.jsx
@@ -4,198 +4,279 @@ import { useTranslation } from 'react-i18next'
 import { cn } from '../../utils/helpers'
 import PayloadName from '../ui/PayloadName'
 import HudButton from '../ui/HudButton'
+import Atmosphere from '../ui/Atmosphere'
+import { useTheme } from '../../theme/ThemeContext'
 
 const AutoloadOverlay = ({ status, onCancel, onFinish, isPS5 }) => {
   const { t } = useTranslation()
-  const isCountdown = status.remaining > 0 || (status.remaining === 0 && !status.current);
-  const isExecuting = status.remaining === 0 && !!status.current && status.current !== 'DONE';
-  const isDone = status.current === 'DONE';
-  const payloadList = (typeof status.list === 'string') ? status.list.split(',').filter(p => p.trim() !== '') : [];
-  const listRef = useRef(null);
-  const displayTotal = status.total > 0 ? status.total : payloadList.length;
-  const progress = displayTotal > 0 ? (status.done / displayTotal) : 0;
+  const { themeId } = useTheme()
+  const isCyber = themeId === 'cyberpunk'
 
-  const [localMs, setLocalMs] = useState(status.remaining_ms ?? (status.remaining * 1000));
+  const isCountdown = status.remaining > 0 || (status.remaining === 0 && !status.current)
+  const isExecuting = status.remaining === 0 && !!status.current && status.current !== 'DONE'
+  const isDone = status.current === 'DONE'
+  const payloadList =
+    typeof status.list === 'string'
+      ? status.list.split(',').filter((p) => p.trim() !== '')
+      : []
+  const listRef = useRef(null)
+  const displayTotal = status.total > 0 ? status.total : payloadList.length
+  const progress = displayTotal > 0 ? status.done / displayTotal : 0
 
-  useEffect(() => {
-    const serverMs = status.remaining_ms ?? (status.remaining * 1000);
-    // Only sync downward (forward in time): server can pull us closer to 0 if we drift,
-    // but never push us back. This ensures a smooth, non-jumping countdown.
-    setLocalMs(prev => serverMs < prev ? serverMs : prev);
-  }, [status.remaining_ms, status.remaining]);
-
-  const isActiveRef = useRef(true);
+  const [localMs, setLocalMs] = useState(status.remaining_ms ?? status.remaining * 1000)
 
   useEffect(() => {
-    if (!isCountdown) return;
-    let lastTime = performance.now();
-    let frameId;
+    const serverMs = status.remaining_ms ?? status.remaining * 1000
+    // Only sync downward so countdown never jumps backwards.
+    setLocalMs((prev) => (serverMs < prev ? serverMs : prev))
+  }, [status.remaining_ms, status.remaining])
+
+  const isActiveRef = useRef(true)
+
+  useEffect(() => {
+    if (!isCountdown) return
+    let lastTime = performance.now()
+    let frameId
     const animate = (time) => {
-      const delta = time - lastTime;
-      lastTime = time;
+      const delta = time - lastTime
+      lastTime = time
       if (isActiveRef.current) {
-        setLocalMs(prev => Math.max(0, prev - delta));
+        setLocalMs((prev) => Math.max(0, prev - delta))
       }
-      frameId = requestAnimationFrame(animate);
-    };
-    frameId = requestAnimationFrame(animate);
-    return () => cancelAnimationFrame(frameId);
-  }, [isCountdown]);
+      frameId = requestAnimationFrame(animate)
+    }
+    frameId = requestAnimationFrame(animate)
+    return () => cancelAnimationFrame(frameId)
+  }, [isCountdown])
 
   useEffect(() => {
     if (listRef.current) {
-      const activeItem = listRef.current.querySelector('[data-active="true"]');
+      const activeItem = listRef.current.querySelector('[data-active="true"]')
       if (activeItem) {
-        activeItem.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        activeItem.scrollIntoView({ behavior: 'smooth', block: 'center' })
       }
     }
-  }, [status.done]);
+  }, [status.done])
 
   return (
-    <div className="fixed inset-0 bg-[#08080a] z-[9999] flex flex-col items-center justify-center p-6 md:p-12 overflow-y-auto custom-scrollbar">
-      <div className={cn(
-        "relative w-full max-w-[1400px] flex flex-col items-center",
-        isPS5 ? "flex-row items-center justify-center space-x-24 space-y-0" : "md:flex-row md:items-start md:justify-center md:space-x-24 md:space-y-0 space-y-12"
-      )}>
+    <div
+      className={cn('cp-autoload-overlay', isCyber && 'ps5-bg')}
+      data-theme={themeId}
+    >
+      {isCyber && <Atmosphere />}
+      {isCyber && <div className="cp-hazard shrink-0" aria-hidden="true" />}
 
-        {/* LEFT COLUMN: Status, Countdown, Success, Actions */}
-        <div className={cn(
-          "w-full max-w-md flex flex-col items-center space-y-10",
-          !isPS5 && "md:sticky md:top-0"
-        )}>
-          {/* Conflict Warning */}
-          {!isDone && (payloadList.some(p => p.toLowerCase().includes('etahen')) &&
-            payloadList.some(p => p.toLowerCase().includes('kstuff'))) && (
-              <div className="w-full p-4 bg-amber-500/10 border border-amber-500/50 rounded-2xl flex items-center justify-center space-x-3 text-amber-500 animate-in fade-in">
-                <AlertTriangle className="w-5 h-5" />
-                <span className="font-bold uppercase tracking-tight text-xs">{t("autoload_overlay.conflict", "Conflict: etaHEN + KStuff active")}</span>
+      <div
+        className={cn(
+          'cp-autoload-overlay__inner relative z-[1] w-full max-w-[1400px] flex flex-col items-center',
+          isPS5
+            ? 'flex-row items-center justify-center space-x-24 space-y-0'
+            : 'md:flex-row md:items-start md:justify-center md:space-x-24 md:space-y-0 space-y-12'
+        )}
+      >
+        {/* LEFT: status + actions */}
+        <div
+          className={cn(
+            'w-full max-w-md flex flex-col items-center space-y-10',
+            !isPS5 && 'md:sticky md:top-0'
+          )}
+        >
+          {!isDone &&
+            payloadList.some((p) => p.toLowerCase().includes('etahen')) &&
+            payloadList.some((p) => p.toLowerCase().includes('kstuff')) && (
+              <div className="cp-autoload-overlay__warn">
+                <AlertTriangle className="w-5 h-5 shrink-0" />
+                <span>
+                  {t('autoload_overlay.conflict', 'Conflict: etaHEN + KStuff active')}
+                </span>
               </div>
             )}
 
-          {/* Status Header */}
           <div className="h-[320px] w-full flex flex-col items-center justify-center">
             {isCountdown && (
-              <div className="space-y-8 animate-in fade-in zoom-in duration-300 text-center">
-                <p className="text-ps-blue font-extrabold tracking-[0.2em] uppercase text-xl">{t("autoload_overlay.autoloading", "Autoloading")}</p>
-                <div className="relative h-56 w-56 mx-auto flex items-center justify-center">
+              <div className="cp-autoload-overlay__status animate-in fade-in zoom-in duration-300">
+                <p className="cp-autoload-overlay__eyebrow">
+                  {t('autoload_overlay.autoloading', 'Autoloading')}
+                </p>
+                <div className="cp-autoload-overlay__ring">
                   <svg className="absolute inset-0 w-full h-full -rotate-90 scale-110">
-                    <circle cx="112" cy="112" r="100" fill="none" stroke="currentColor" strokeWidth="8" className="text-white/5" />
                     <circle
-                      cx="112" cy="112" r="100"
-                      fill="none" stroke="currentColor" strokeWidth="8"
+                      cx="112"
+                      cy="112"
+                      r="100"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="8"
+                      className="cp-autoload-overlay__ring-track"
+                    />
+                    <circle
+                      cx="112"
+                      cy="112"
+                      r="100"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="8"
                       strokeDasharray="628"
-                      strokeDashoffset={628 - (628 * (localMs / ((status.delay || 5) * 1000)))}
-                      className="text-ps-blue"
+                      strokeDashoffset={
+                        628 - 628 * (localMs / ((status.delay || 5) * 1000))
+                      }
+                      className="cp-autoload-overlay__ring-fill"
                     />
                   </svg>
-                  <span className="text-8xl font-bold text-white tabular-nums leading-none">
+                  <span className="cp-autoload-overlay__ring-num">
                     {Math.ceil(localMs / 1000)}
                   </span>
                 </div>
-                <p className="text-zinc-500 font-bold uppercase tracking-widest text-sm">{t("autoload_overlay.waiting", "Waiting for manual abort...")}</p>
+                <p className="cp-autoload-overlay__hint">
+                  {t('autoload_overlay.waiting', 'Waiting for manual abort...')}
+                </p>
               </div>
             )}
 
             {isExecuting && (
-              <div className="space-y-8 animate-in fade-in zoom-in duration-300 text-center">
-                <p className="text-ps-blue font-black tracking-[0.4em] uppercase text-xl">{t("autoload_overlay.executing", "Executing")}</p>
-                <div className="relative h-56 w-56 mx-auto flex items-center justify-center">
+              <div className="cp-autoload-overlay__status animate-in fade-in zoom-in duration-300">
+                <p className="cp-autoload-overlay__eyebrow">
+                  {t('autoload_overlay.executing', 'Executing')}
+                </p>
+                <div className="cp-autoload-overlay__ring">
                   <svg className="absolute inset-0 w-full h-full -rotate-90 scale-110">
-                    <circle cx="112" cy="112" r="100" fill="none" stroke="currentColor" strokeWidth="8" className="text-white/5" />
                     <circle
-                      cx="112" cy="112" r="100"
-                      fill="none" stroke="currentColor" strokeWidth="8"
+                      cx="112"
+                      cy="112"
+                      r="100"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="8"
+                      className="cp-autoload-overlay__ring-track"
+                    />
+                    <circle
+                      cx="112"
+                      cy="112"
+                      r="100"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="8"
                       strokeDasharray="628"
-                      strokeDashoffset={628 - (628 * progress)}
-                      className="text-ps-blue transition-all duration-500 ease-out"
+                      strokeDashoffset={628 - 628 * progress}
+                      className="cp-autoload-overlay__ring-fill transition-all duration-500 ease-out"
                     />
                   </svg>
-                  <span className="text-6xl font-black text-white tabular-nums leading-none">
+                  <span className="cp-autoload-overlay__ring-num cp-autoload-overlay__ring-num--pct">
                     {Math.round(progress * 100)}%
                   </span>
                 </div>
-                <p className="text-zinc-500 font-bold uppercase tracking-widest text-sm italic">{t("autoload_overlay.loading", "Loading Payloads...")}</p>
+                <p className="cp-autoload-overlay__hint italic">
+                  {t('autoload_overlay.loading', 'Loading Payloads...')}
+                </p>
               </div>
             )}
 
             {isDone && (
-              <div className="flex flex-col items-center space-y-8 animate-in zoom-in duration-500">
-                <div className="bg-emerald-500 text-white p-10 rounded-full">
-                  <CheckCircle2 className="w-20 h-20" />
+              <div className="cp-autoload-overlay__done animate-in zoom-in duration-500">
+                <div className="cp-autoload-overlay__done-icon" aria-hidden="true">
+                  <CheckCircle2 className="w-16 h-16 md:w-20 md:h-20" />
                 </div>
                 <div className="text-center space-y-2">
-                  <h2 className="text-5xl md:text-6xl font-black text-white uppercase tracking-tighter">{t("autoload_overlay.done_title_1", "Autoload")}<br />{t("autoload_overlay.done_title_2", "Done")}</h2>
-                  <p className="text-zinc-500 font-bold uppercase text-sm tracking-[0.2em]">{t("autoload_overlay.all_loaded", "All payloads loaded")}</p>
+                  <h2 className="cp-autoload-overlay__done-title">
+                    {t('autoload_overlay.done_title_1', 'Autoload')}
+                    <br />
+                    {t('autoload_overlay.done_title_2', 'Done')}
+                  </h2>
+                  <p className="cp-autoload-overlay__hint">
+                    {t('autoload_overlay.all_loaded', 'All payloads loaded')}
+                  </p>
                 </div>
               </div>
             )}
           </div>
 
-          {/* Action Buttons */}
           <div className="w-full pt-4">
             {isDone ? (
-              <HudButton onClick={onFinish} variant="primary" size="lg" block className="cp-btn--bar !min-h-[4.5rem] !text-xl">
-                {t("autoload_overlay.return_btn", "Return to Dashboard")}
+              <HudButton
+                onClick={onFinish}
+                variant="primary"
+                size="lg"
+                block
+                className="cp-btn--bar !min-h-[4.5rem] !text-xl"
+              >
+                {t('autoload_overlay.return_btn', 'Return to Dashboard')}
               </HudButton>
             ) : isCountdown ? (
-              <HudButton onClick={onCancel} autoFocus variant="danger" size="lg" block className="cp-btn--bar !min-h-[4.5rem] !text-xl">
-                {t("autoload_overlay.abort_btn", "Abort Autoload")}
+              <HudButton
+                onClick={onCancel}
+                autoFocus
+                variant="danger"
+                size="lg"
+                block
+                className="cp-btn--bar !min-h-[4.5rem] !text-xl"
+              >
+                {t('autoload_overlay.abort_btn', 'Abort Autoload')}
               </HudButton>
             ) : (
               <div className="h-[92px] w-full flex items-center justify-center">
-                <div className="flex space-x-2">
-                  <div className="w-2 h-2 bg-ps-blue rounded-full animate-bounce" />
-                  <div className="w-2 h-2 bg-ps-blue rounded-full animate-bounce [animation-delay:0.2s]" />
-                  <div className="w-2 h-2 bg-ps-blue rounded-full animate-bounce [animation-delay:0.4s]" />
+                <div className="cp-autoload-overlay__dots">
+                  <span />
+                  <span />
+                  <span />
                 </div>
               </div>
             )}
           </div>
         </div>
 
+        {/* RIGHT: payload list */}
         <div className="w-full max-w-xl flex flex-col min-h-0">
           <div
             ref={listRef}
             className={cn(
-              "w-full space-y-4 overflow-y-auto custom-scrollbar p-8 bg-white/5 rounded-[2.5rem] border border-white/10 scroll-smooth",
-              isPS5 ? "h-[650px]" : "h-[400px] md:h-[650px]"
+              'cp-autoload-overlay__list glass-card custom-scrollbar scroll-smooth',
+              isPS5 ? 'h-[650px]' : 'h-[400px] md:h-[650px]'
             )}
           >
-            <div className="flex items-center justify-between mb-6 px-2 sticky top-0 bg-black/20 py-4 z-10 rounded-2xl border-b border-white/5">
-              <h3 className="label-caps !text-white !opacity-100 text-sm tracking-widest flex items-center space-x-3">
-                <span>{t("autoload_overlay.payload_list", "Payload List")}</span>
+            <div className="cp-autoload-overlay__list-head">
+              <h3 className="label-caps !opacity-100 text-sm tracking-widest">
+                {t('autoload_overlay.payload_list', 'Payload List')}
               </h3>
-              <span className="bg-white/10 px-4 py-1 rounded-full text-zinc-300 font-black text-xs">
+              <span className="cp-autoload-overlay__count">
                 {isDone ? displayTotal : status.done} / {displayTotal}
               </span>
             </div>
 
             <div className="space-y-3">
               {payloadList.map((name, i) => {
-                const active = !isDone && isExecuting && i === status.done;
-                const done = isDone || i < status.done;
+                const active = !isDone && isExecuting && i === status.done
+                const done = isDone || i < status.done
                 return (
                   <div
                     key={i}
                     data-active={active}
                     className={cn(
-                      "flex items-center justify-between p-5 rounded-2xl border transition-all duration-500",
-                      active ? 'bg-ps-blue/20 border-ps-blue scale-[1.02] z-10' :
-                        done ? 'bg-emerald-500/5 border-emerald-500/20 opacity-100' : 'bg-white/5 border-white/10 opacity-40'
-                    )}>
-                    <div className="flex items-center space-x-5">
-                      {done ? <CheckCircle2 className="w-6 h-6 text-emerald-500" /> :
-                        active ? <Loader2 className="w-6 h-6 text-ps-blue animate-spin" /> :
-                          <div className="w-6 h-6 rounded-full border-2 border-white/10" />}
+                      'cp-autoload-overlay__item glass-card',
+                      active && 'is-active',
+                      done && 'is-done',
+                      !active && !done && 'is-pending'
+                    )}
+                  >
+                    <div className="flex items-center space-x-5 min-w-0">
+                      {done ? (
+                        <CheckCircle2 className="cp-autoload-overlay__item-icon is-done w-6 h-6 shrink-0" />
+                      ) : active ? (
+                        <Loader2 className="cp-autoload-overlay__item-icon is-active w-6 h-6 shrink-0 animate-spin" />
+                      ) : (
+                        <div className="cp-autoload-overlay__item-icon is-pending w-6 h-6 shrink-0" />
+                      )}
                       <PayloadName
                         path={name}
-                        className={cn("text-xl font-bold", active ? 'text-white' : 'text-zinc-100')}
+                        className={cn(
+                          'text-xl font-bold min-w-0',
+                          active ? 'text-white' : 'text-zinc-100'
+                        )}
                         stacked
                       />
                     </div>
                     {done && (
-                      <span className="text-emerald-500 text-[10px] font-black uppercase tracking-widest italic">
-                        {t("autoload_overlay.success", "Success")}
+                      <span className="cp-autoload-overlay__item-tag">
+                        {t('autoload_overlay.success', 'Success')}
                       </span>
                     )}
                   </div>
@@ -204,7 +285,6 @@ const AutoloadOverlay = ({ status, onCancel, onFinish, isPS5 }) => {
             </div>
           </div>
         </div>
-
       </div>
     </div>
   )

--- a/frontend/src/components/views/AutoloadOverlay.jsx
+++ b/frontend/src/components/views/AutoloadOverlay.jsx
@@ -9,8 +9,9 @@ import { useTheme } from '../../theme/ThemeContext'
 
 const AutoloadOverlay = ({ status, onCancel, onFinish, isPS5 }) => {
   const { t } = useTranslation()
-  const { themeId } = useTheme()
-  const isCyber = themeId === 'cyberpunk'
+  const { themeId, hasFeature } = useTheme()
+  const showAtmosphere = hasFeature('atmosphere')
+  const showHazard = hasFeature('hazardStripe')
 
   const isCountdown = status.remaining > 0 || (status.remaining === 0 && !status.current)
   const isExecuting = status.remaining === 0 && !!status.current && status.current !== 'DONE'
@@ -60,11 +61,11 @@ const AutoloadOverlay = ({ status, onCancel, onFinish, isPS5 }) => {
 
   return (
     <div
-      className={cn('cp-autoload-overlay', isCyber && 'ps5-bg')}
+      className={cn('cp-autoload-overlay', showAtmosphere && 'ps5-bg')}
       data-theme={themeId}
     >
-      {isCyber && <Atmosphere />}
-      {isCyber && <div className="cp-hazard shrink-0" aria-hidden="true" />}
+      {showAtmosphere && <Atmosphere />}
+      {showHazard && <div className="cp-hazard shrink-0" aria-hidden="true" />}
 
       <div
         className={cn(

--- a/frontend/src/components/views/AutoloadView.jsx
+++ b/frontend/src/components/views/AutoloadView.jsx
@@ -204,16 +204,10 @@ const AutoloadView = ({ payloads, config, onSaveConfig, onToast, onRedirect }) =
         {isCyberpunk ? (
           <div className="flex items-center gap-4 shrink-0">
             <span className="label-caps !text-zinc-400 !opacity-100 text-xs md:text-sm tracking-[0.16em] whitespace-nowrap">
-              {t("autoload.disable_btn", "Disable Autoload")}
+              {t("autoload.enable_btn", "Enable Autoload")}
             </span>
-            {/*
-              Label is "Disable Autoload": ON = disabled (autoload off).
-              Flip to OFF to keep sequence enabled.
-            */}
-            <ToggleSwitch
-              on={!enabled}
-              onChange={(disable) => handleToggle(!disable)}
-            />
+            {/* ON = sequence active */}
+            <ToggleSwitch on={enabled} onChange={handleToggle} />
           </div>
         ) : (
           <HudButton onClick={() => handleToggle(false)} variant="dangerSoft" size="sm">
@@ -265,40 +259,54 @@ const AutoloadView = ({ payloads, config, onSaveConfig, onToast, onRedirect }) =
 
   if (!enabled) {
     return (
-      <div className="flex-1 flex flex-col items-center justify-center space-y-8 text-center p-6 md:p-12">
-        <div className="relative h-24 w-24 md:h-32 md:w-32 mx-auto">
-          <div className="absolute inset-0 bg-ps-blue/20 rounded-full" />
-          <div className="relative flex items-center justify-center h-full w-full bg-black/40 border border-white/10 rounded-3xl md:rounded-[2.5rem] shadow-2xl">
-            <RefreshCw className="w-10 h-10 md:w-16 md:h-16 text-ps-blue" />
+      <div className="cp-autoload-off">
+        <div className="cp-autoload-off__panel">
+          <div className="cp-autoload-off__icon" aria-hidden="true">
+            <Zap className="w-10 h-10 md:w-12 md:h-12" />
+          </div>
+          <div className="cp-autoload-off__copy">
+            <h2 className="cp-autoload-off__title">
+              {t("autoload.sequence_title_1", "Autoload")}{' '}
+              <span className="cp-title-accent">{t("autoload.sequence_title_2", "Sequence")}</span>
+            </h2>
+            <p className="cp-autoload-off__desc">
+              {t(
+                "autoload.enable_desc",
+                "Chain multiple payloads to be executed automatically every time Payload Manager starts."
+              )}
+            </p>
+            <p className="cp-autoload-off__status">
+              {t("autoload.disabled_status", "Autoload is currently off")}
+            </p>
+          </div>
+          <div className="cp-autoload-off__actions">
+            <HudButton
+              onClick={() => handleToggle(true)}
+              icon={Zap}
+              variant="primary"
+              size="lg"
+              block
+              className={isCyberpunk ? 'cp-btn--bar' : undefined}
+            >
+              {t("autoload.enable_btn", "Enable Autoload")}
+            </HudButton>
+            {(saving || saved) && (
+              <div className="cp-autoload-off__save">
+                {saving ? (
+                  <>
+                    <RefreshCw className="w-3.5 h-3.5 animate-spin" />
+                    <span>{t("autoload.saving", "Saving Changes...")}</span>
+                  </>
+                ) : (
+                  <>
+                    <CheckCircle2 className="w-3.5 h-3.5" />
+                    <span>{t("autoload.saved", "All Changes Saved")}</span>
+                  </>
+                )}
+              </div>
+            )}
           </div>
         </div>
-        <div className="space-y-3 md:space-y-4 px-4 max-w-2xl">
-          <h2 className="text-3xl md:text-5xl font-black text-white uppercase italic tracking-tighter">
-            {t("autoload.sequence_title_1", "Autoload")} <span className="cp-title-accent">{t("autoload.sequence_title_2", "Sequence")}</span>
-          </h2>
-          <p className="text-md md:text-xl text-zinc-400 font-medium leading-relaxed">
-            {t("autoload.enable_desc", "Chain multiple payloads to be executed automatically every time Payload Manager starts.")}
-          </p>
-        </div>
-        {isCyberpunk ? (
-          <div className="flex flex-col items-center gap-5">
-            <span className="label-caps !text-zinc-400 !opacity-100 text-sm tracking-[0.16em]">
-              {t("autoload.disable_btn", "Disable Autoload")}
-            </span>
-            {/*
-              Autoload is currently off → Disable is ON.
-              Switch to OFF to enable the sequence.
-            */}
-            <ToggleSwitch
-              on={!enabled}
-              onChange={(disable) => handleToggle(!disable)}
-            />
-          </div>
-        ) : (
-          <HudButton onClick={() => handleToggle(true)} variant="primary" size="lg">
-            {t("autoload.enable_btn", "Enable Autoload")}
-          </HudButton>
-        )}
       </div>
     )
   }

--- a/frontend/src/components/views/AutoloadView.jsx
+++ b/frontend/src/components/views/AutoloadView.jsx
@@ -166,7 +166,7 @@ const AutoloadView = ({ payloads, config, onSaveConfig, onToast, onRedirect }) =
       <div className="flex items-center justify-between shrink-0">
         <div className="flex flex-col">
           <h2 className="text-4xl font-extrabold text-white tracking-tight">
-            {t("autoload.sequence_title_1", "Autoload")} <span className="text-ps-blue">{t("autoload.sequence_title_2", "Sequence")}</span>
+            {t("autoload.sequence_title_1", "Autoload")} <span className="cp-title-accent">{t("autoload.sequence_title_2", "Sequence")}</span>
           </h2>
           <div className="h-6 mt-1 overflow-hidden">
             {saving ? (
@@ -245,7 +245,7 @@ const AutoloadView = ({ payloads, config, onSaveConfig, onToast, onRedirect }) =
         </div>
         <div className="space-y-3 md:space-y-4 px-4 max-w-2xl">
           <h2 className="text-3xl md:text-5xl font-black text-white uppercase italic tracking-tighter">
-            {t("autoload.sequence_title_1", "Autoload")} <span className="text-ps-blue">{t("autoload.sequence_title_2", "Sequence")}</span>
+            {t("autoload.sequence_title_1", "Autoload")} <span className="cp-title-accent">{t("autoload.sequence_title_2", "Sequence")}</span>
           </h2>
           <p className="text-md md:text-xl text-zinc-400 font-medium leading-relaxed">
             {t("autoload.enable_desc", "Chain multiple payloads to be executed automatically every time Payload Manager starts.")}

--- a/frontend/src/components/views/AutoloadView.jsx
+++ b/frontend/src/components/views/AutoloadView.jsx
@@ -10,8 +10,8 @@ import { useTheme } from '../../theme/ThemeContext'
 
 const AutoloadView = ({ payloads, config, onSaveConfig, onToast, onRedirect }) => {
   const { t } = useTranslation()
-  const { themeId } = useTheme()
-  const isCyberpunk = themeId === 'cyberpunk'
+  const { hasFeature } = useTheme()
+  const hudControls = hasFeature('hudControls')
   const [subView, setSubView] = useState('list')
   const [enabled, setEnabled] = useState(false)
   const [autoloadList, setAutoloadList] = useState([])
@@ -201,7 +201,7 @@ const AutoloadView = ({ payloads, config, onSaveConfig, onToast, onRedirect }) =
             ) : null}
           </div>
         </div>
-        {isCyberpunk ? (
+        {hudControls ? (
           <div className="flex items-center gap-4 shrink-0">
             <span className="label-caps !text-zinc-400 !opacity-100 text-xs md:text-sm tracking-[0.16em] whitespace-nowrap">
               {t("autoload.enable_btn", "Enable Autoload")}
@@ -286,7 +286,7 @@ const AutoloadView = ({ payloads, config, onSaveConfig, onToast, onRedirect }) =
               variant="primary"
               size="lg"
               block
-              className={isCyberpunk ? 'cp-btn--bar' : undefined}
+              className={hudControls ? 'cp-btn--bar' : undefined}
             >
               {t("autoload.enable_btn", "Enable Autoload")}
             </HudButton>

--- a/frontend/src/components/views/AutoloadView.jsx
+++ b/frontend/src/components/views/AutoloadView.jsx
@@ -4,9 +4,14 @@ import { cn, isPS5, isSystemPayload } from '../../utils/helpers'
 import { useTranslation } from 'react-i18next'
 import PayloadName from '../ui/PayloadName'
 import Modal from '../ui/Modal'
+import ToggleSwitch from '../ui/ToggleSwitch'
+import HudButton from '../ui/HudButton'
+import { useTheme } from '../../theme/ThemeContext'
 
 const AutoloadView = ({ payloads, config, onSaveConfig, onToast, onRedirect }) => {
   const { t } = useTranslation()
+  const { themeId } = useTheme()
+  const isCyberpunk = themeId === 'cyberpunk'
   const [subView, setSubView] = useState('list')
   const [enabled, setEnabled] = useState(false)
   const [autoloadList, setAutoloadList] = useState([])
@@ -103,46 +108,60 @@ const AutoloadView = ({ payloads, config, onSaveConfig, onToast, onRedirect }) =
       <div className="flex items-center justify-between shrink-0">
         <div className="flex items-center space-x-4">
           {subView === 'add' && (
-            <button onClick={() => setSubView('list')} className="p-2 bg-white/5 rounded-xl border border-white/10 lg:hidden">
-              <ArrowLeft className="w-5 h-5" />
-            </button>
+            <HudButton
+              onClick={() => setSubView('list')}
+              icon={ArrowLeft}
+              variant="secondary"
+              size="sm"
+              className="cp-btn--icon lg:hidden"
+              aria-label="Back"
+            />
           )}
           <h3 className="label-caps !text-white !opacity-100 text-xl tracking-widest">{t("autoload.available_title", "Available Payloads")}</h3>
         </div>
       </div>
       <div className="flex-1 overflow-y-auto pr-2 custom-scrollbar min-h-0 pb-6">
-        <div className="grid grid-cols-1 gap-4">
+        <div className="grid grid-cols-1 gap-3">
           {availablePayloads.map(p => {
             const isKstuff = p.toLowerCase().includes('kstuff');
             const hasKstuff = autoloadList.some(x => x.toLowerCase().includes('kstuff'));
             const isBlocked = isKstuff && hasKstuff;
 
             return (
-              <button
+              <HudButton
                 key={p}
                 onClick={() => !isBlocked && addPayload(p)}
                 disabled={isBlocked}
+                endIcon={ArrowRight}
+                variant="secondary"
+                size="lg"
+                block
+                raw
                 className={cn(
-                  "flex items-start justify-between p-6 glass-card rounded-2xl border-white/20 transition-all text-left",
-                  isBlocked ? "opacity-40 cursor-not-allowed" : "bg-white/[0.03] hover:border-ps-blue group"
+                  'cp-btn--bar cp-btn--payload-row',
+                  isBlocked && 'opacity-40'
                 )}
               >
-                <PayloadName path={p} className={cn("text-xl", isBlocked ? "text-zinc-500" : "text-white")} stacked />
-                <ArrowRight className={cn("w-6 h-6 transition-all shrink-0 mt-1", isBlocked ? "text-zinc-800" : "text-zinc-500 group-hover:text-ps-blue group-hover:translate-x-2")} />
-              </button>
+                <PayloadName
+                  path={p}
+                  className={cn('text-lg md:text-xl', isBlocked ? 'text-zinc-500' : 'text-white')}
+                  stacked
+                />
+              </HudButton>
             )
           })}
-          <div className="pt-4 border-t border-white/10 mt-4">
-            <button
+          <div className="pt-4 border-t border-white/10 mt-2">
+            <HudButton
               onClick={() => setShowDelayModal(true)}
-              className="w-full flex items-center justify-between p-6 bg-white/[0.03] rounded-2xl border border-dashed border-white/20 hover:border-ps-blue group transition-all"
+              icon={Zap}
+              endIcon={ArrowRight}
+              variant="primary"
+              size="lg"
+              block
+              className="cp-btn--bar"
             >
-              <div className="flex items-center space-x-4">
-                <Zap className="w-6 h-6 text-ps-blue" />
-                <span className="font-bold text-white uppercase tracking-tight text-xl">{t("autoload.add_delay_btn", "Add Delay")}</span>
-              </div>
-              <ArrowRight className="w-6 h-6 text-zinc-500 group-hover:text-ps-blue group-hover:translate-x-2 transition-all" />
-            </button>
+              {t("autoload.add_delay_btn", "Add Delay")}
+            </HudButton>
           </div>
           <div className="pt-8 border-t border-white/5 mt-8 text-center space-y-4">
             <p className="text-zinc-500 text-sm font-bold uppercase tracking-widest opacity-60">{t("autoload.missing_payload", "Missing a payload?")}</p>
@@ -182,12 +201,25 @@ const AutoloadView = ({ payloads, config, onSaveConfig, onToast, onRedirect }) =
             ) : null}
           </div>
         </div>
-        <button
-          onClick={() => handleToggle(false)}
-          className="px-4 py-2 rounded-xl font-black uppercase italic tracking-tighter bg-red-600/10 text-red-500 border border-red-500/30 hover:bg-red-600 hover:text-white transition-all shadow-lg text-xs"
-        >
-          {t("autoload.disable_btn", "Disable Autoload")}
-        </button>
+        {isCyberpunk ? (
+          <div className="flex items-center gap-4 shrink-0">
+            <span className="label-caps !text-zinc-400 !opacity-100 text-xs md:text-sm tracking-[0.16em] whitespace-nowrap">
+              {t("autoload.disable_btn", "Disable Autoload")}
+            </span>
+            {/*
+              Label is "Disable Autoload": ON = disabled (autoload off).
+              Flip to OFF to keep sequence enabled.
+            */}
+            <ToggleSwitch
+              on={!enabled}
+              onChange={(disable) => handleToggle(!disable)}
+            />
+          </div>
+        ) : (
+          <HudButton onClick={() => handleToggle(false)} variant="dangerSoft" size="sm">
+            {t("autoload.disable_btn", "Disable Autoload")}
+          </HudButton>
+        )}
       </div>
 
       <div className="glass-panel p-6 rounded-ps-3xl border-white/10 flex-1 overflow-hidden flex flex-col min-h-0">
@@ -200,16 +232,10 @@ const AutoloadView = ({ payloads, config, onSaveConfig, onToast, onRedirect }) =
               <div className="flex items-center min-w-0 pl-2">
                 <PayloadName path={p} className="text-white" stacked />
               </div>
-              <div className="flex items-center space-x-2">
-                <button onClick={() => moveUp(i)} disabled={i === 0} className="p-2 bg-white/10 text-zinc-400 hover:bg-ps-blue hover:text-white rounded-xl disabled:opacity-20">
-                  <ChevronUp className="w-5 h-5" />
-                </button>
-                <button onClick={() => moveDown(i)} disabled={i === autoloadList.length - 1} className="p-2 bg-white/10 text-zinc-400 hover:bg-ps-blue hover:text-white rounded-xl disabled:opacity-20">
-                  <ChevronDown className="w-5 h-5" />
-                </button>
-                <button onClick={() => setAutoloadList(autoloadList.filter((_, idx) => idx !== i))} className="p-2 bg-white/10 text-zinc-400 hover:bg-red-600 hover:text-white rounded-xl">
-                  <Trash2 className="w-5 h-5" />
-                </button>
+              <div className="flex items-center gap-2">
+                <HudButton onClick={() => moveUp(i)} disabled={i === 0} icon={ChevronUp} variant="secondary" size="sm" className="cp-btn--icon" aria-label="Move up" />
+                <HudButton onClick={() => moveDown(i)} disabled={i === autoloadList.length - 1} icon={ChevronDown} variant="secondary" size="sm" className="cp-btn--icon" aria-label="Move down" />
+                <HudButton onClick={() => setAutoloadList(autoloadList.filter((_, idx) => idx !== i))} icon={Trash2} variant="dangerSoft" size="sm" className="cp-btn--icon" aria-label="Remove" />
               </div>
             </div>
           ))}
@@ -221,13 +247,16 @@ const AutoloadView = ({ payloads, config, onSaveConfig, onToast, onRedirect }) =
           )}
 
           <div className={cn("pt-4 mt-2", isPS5 ? "hidden" : "lg:hidden")}>
-            <button
+            <HudButton
               onClick={() => setSubView('add')}
-              className="w-full flex items-center justify-center space-x-4 p-6 bg-ps-blue/10 hover:bg-ps-blue text-ps-blue hover:text-white rounded-2xl border border-dashed border-ps-blue/30 hover:border-ps-blue transition-all group shadow-lg"
+              icon={Activity}
+              variant="primary"
+              size="lg"
+              block
+              className="cp-btn--bar"
             >
-              <Activity className="w-6 h-6" />
-              <span className="font-black italic text-xl uppercase tracking-tighter">{t("autoload.add_item_btn", "Add Item to Sequence")}</span>
-            </button>
+              {t("autoload.add_item_btn", "Add Item to Sequence")}
+            </HudButton>
           </div>
         </div>
       </div>
@@ -251,12 +280,25 @@ const AutoloadView = ({ payloads, config, onSaveConfig, onToast, onRedirect }) =
             {t("autoload.enable_desc", "Chain multiple payloads to be executed automatically every time Payload Manager starts.")}
           </p>
         </div>
-        <button
-          onClick={() => handleToggle(true)}
-          className="px-8 md:px-12 py-5 md:py-6 bg-ps-blue text-white text-lg md:text-2xl font-extrabold rounded-2xl md:rounded-[1.5rem] hover:bg-ps-blue/80 transition-all transform active:scale-95 shadow-[0_0_40px_rgba(0,149,255,0.3)]"
-        >
-          {t("autoload.enable_btn", "Enable Autoload")}
-        </button>
+        {isCyberpunk ? (
+          <div className="flex flex-col items-center gap-5">
+            <span className="label-caps !text-zinc-400 !opacity-100 text-sm tracking-[0.16em]">
+              {t("autoload.disable_btn", "Disable Autoload")}
+            </span>
+            {/*
+              Autoload is currently off → Disable is ON.
+              Switch to OFF to enable the sequence.
+            */}
+            <ToggleSwitch
+              on={!enabled}
+              onChange={(disable) => handleToggle(!disable)}
+            />
+          </div>
+        ) : (
+          <HudButton onClick={() => handleToggle(true)} variant="primary" size="lg">
+            {t("autoload.enable_btn", "Enable Autoload")}
+          </HudButton>
+        )}
       </div>
     )
   }
@@ -284,24 +326,23 @@ const AutoloadView = ({ payloads, config, onSaveConfig, onToast, onRedirect }) =
         title={t("autoload.delay_modal.title", "Configure Delay")}
         onClose={() => setShowDelayModal(false)}
         footer={
-          <button
-            onClick={() => setShowDelayModal(false)}
-            className="w-full py-4 bg-white/5 hover:bg-white/10 text-white rounded-2xl font-bold uppercase tracking-tight transition-all"
-          >
+          <HudButton onClick={() => setShowDelayModal(false)} variant="secondary" block>
             {t("autoload.delay_modal.cancel", "Cancel")}
-          </button>
+          </HudButton>
         }
       >
         <div className="space-y-6 md:space-y-8">
           <div className="grid grid-cols-3 gap-3 md:gap-4">
             {[1, 3, 5].map(s => (
-              <button
+              <HudButton
                 key={s}
                 onClick={() => addDelay(s * 1000)}
-                className="py-4 md:py-6 bg-ps-blue/20 hover:bg-ps-blue border border-ps-blue/30 text-white rounded-2xl font-black text-xl md:text-2xl transition-all shadow-lg"
+                variant="primary"
+                size="lg"
+                className="flex-1"
               >
                 {s}s
-              </button>
+              </HudButton>
             ))}
           </div>
 
@@ -315,12 +356,14 @@ const AutoloadView = ({ payloads, config, onSaveConfig, onToast, onRedirect }) =
                 onChange={(e) => setCustomDelay(e.target.value)}
                 className="flex-1 bg-white/5 border border-white/10 rounded-2xl p-4 md:p-5 text-white font-mono text-xl md:text-2xl focus:border-ps-blue outline-none transition-all"
               />
-              <button
+              <HudButton
                 onClick={() => customDelay && addDelay(parseInt(customDelay))}
-                className="py-4 md:py-0 px-8 md:px-10 bg-ps-blue text-white rounded-2xl font-black uppercase italic tracking-tighter text-lg md:text-xl shadow-2xl hover:bg-ps-blue/80 transition-all shrink-0"
+                variant="primary"
+                size="lg"
+                className="shrink-0"
               >
                 {t("autoload.delay_modal.add_btn", "Add")}
-              </button>
+              </HudButton>
             </div>
           </div>
         </div>

--- a/frontend/src/components/views/DonateView.jsx
+++ b/frontend/src/components/views/DonateView.jsx
@@ -35,9 +35,9 @@ const DonateView = () => {
             href={donateUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="px-10 md:px-16 py-6 md:py-8 bg-red-600 text-white text-xl md:text-3xl font-black uppercase rounded-2xl md:rounded-[2rem] hover:bg-red-500 transition-all transform active:scale-95 shadow-[0_0_50px_rgba(220,38,38,0.4)] text-center block"
+            className="cp-btn cp-btn--danger cp-btn--lg cp-btn--bar text-center no-underline"
           >
-            {t("donate.view_options_btn", "View Donation Options")}
+            <span className="cp-btn__label">{t("donate.view_options_btn", "View Donation Options")}</span>
           </a>
         )}
       </div>

--- a/frontend/src/components/views/DonateView.jsx
+++ b/frontend/src/components/views/DonateView.jsx
@@ -6,7 +6,7 @@ import { isPS5 } from '../../utils/helpers'
 
 const DonateView = () => {
   const { t } = useTranslation()
-  const donateUrl = 'https://github.com/itsPLK/ps5-payload-manager/blob/main/DONATE.md';
+  const donateUrl = 'https://github.com/amilarajans/ps5-payload-manager/blob/main/DONATE.md';
   return (
     <div className="flex flex-col xl:flex-row items-center justify-center min-h-[60vh] animate-fade-in max-w-6xl mx-auto py-10 xl:py-20 gap-12 xl:gap-24">
       {/* Left Column */}

--- a/frontend/src/components/views/LogViewer.jsx
+++ b/frontend/src/components/views/LogViewer.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useRef } from 'react'
 import { ChevronDown } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
+import { cn } from '../../utils/helpers'
+import HudButton from '../ui/HudButton'
 
 const LogViewer = ({ logs }) => {
   const { t } = useTranslation()
@@ -11,7 +13,7 @@ const LogViewer = ({ logs }) => {
   const handleScroll = () => {
     if (!scrollRef.current) return
     const { scrollTop, scrollHeight, clientHeight } = scrollRef.current
-    const atBottom = scrollHeight - scrollTop - clientHeight < 100
+    const atBottom = scrollHeight - scrollTop - clientHeight < 80
     setIsAtBottom(atBottom)
     if (atBottom) setHasNewLogs(false)
   }
@@ -19,7 +21,7 @@ const LogViewer = ({ logs }) => {
   useEffect(() => {
     if (isAtBottom) {
       scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: 'auto' })
-    } else {
+    } else if (logs.length > 0) {
       setHasNewLogs(true)
     }
   }, [logs, isAtBottom])
@@ -31,30 +33,41 @@ const LogViewer = ({ logs }) => {
   }
 
   return (
-    <div className="flex-1 min-h-0 flex flex-col relative group h-full bg-black/40">
+    <div className="cp-log-viewer">
       <div
         ref={scrollRef}
         onScroll={handleScroll}
-        className="flex-1 overflow-y-auto p-4 md:p-8 font-mono text-sm md:text-base space-y-1.5 custom-scrollbar scroll-smooth overscroll-contain"
+        className="cp-log-viewer__scroll custom-scrollbar"
       >
-        {logs.map((log, i) => (
-          <div key={`${i}-${log}`} className="flex space-x-4 opacity-100 border-l-2 border-transparent hover:border-ps-blue hover:bg-white/5 px-3 py-0.5 transition-all">
-            <span className="text-zinc-600 select-none font-bold shrink-0 w-10 text-right pr-2">{i + 1}</span>
-            <span className="text-ps-blue/80 font-bold">»</span>
-            <span className="text-zinc-200 break-all leading-relaxed tracking-tight">{log}</span>
+        {logs.length === 0 ? (
+          <div className="cp-log-viewer__empty">
+            {t("logs.empty", "Waiting for log output…")}
           </div>
-        ))}
-        <div className="h-20" /> {/* Bottom spacing for the button */}
+        ) : (
+          logs.map((log, i) => (
+            <div key={`${i}-${String(log).slice(0, 24)}`} className="cp-log-line">
+              <span className="cp-log-line__num" aria-hidden="true">
+                {String(i + 1).padStart(3, ' ')}
+              </span>
+              <span className="cp-log-line__prompt" aria-hidden="true">»</span>
+              <span className="cp-log-line__text">{log}</span>
+            </div>
+          ))
+        )}
+        <div className="cp-log-viewer__pad" aria-hidden="true" />
       </div>
 
       {!isAtBottom && hasNewLogs && (
-        <button
-          onClick={scrollToBottom}
-          className="absolute bottom-10 inset-x-0 mx-auto w-max px-8 py-4 bg-ps-blue text-black rounded-lg font-black uppercase tracking-[0.2em] text-[11px] z-50 flex items-center space-x-3 border border-ps-yellow/30 shadow-[0_0_50px_rgba(0,240,255,0.35)] animate-bounce hover:scale-105 active:scale-95 transition-transform"
-        >
-          <ChevronDown className="w-5 h-5" />
-          <span>{t("logs.new_activity_btn", "New Activity Below")}</span>
-        </button>
+        <div className="cp-log-viewer__jump">
+          <HudButton
+            onClick={scrollToBottom}
+            icon={ChevronDown}
+            variant="primary"
+            size="sm"
+          >
+            {t("logs.new_activity_btn", "New Activity Below")}
+          </HudButton>
+        </div>
       )}
     </div>
   )

--- a/frontend/src/components/views/LogViewer.jsx
+++ b/frontend/src/components/views/LogViewer.jsx
@@ -50,7 +50,7 @@ const LogViewer = ({ logs }) => {
       {!isAtBottom && hasNewLogs && (
         <button
           onClick={scrollToBottom}
-          className="absolute bottom-10 inset-x-0 mx-auto w-max px-8 py-4 bg-ps-blue text-white rounded-full font-black uppercase tracking-[0.2em] text-[11px] z-50 flex items-center space-x-3 border border-white/20 shadow-[0_0_50px_rgba(0,149,255,0.4)] animate-bounce hover:scale-105 active:scale-95 transition-transform"
+          className="absolute bottom-10 inset-x-0 mx-auto w-max px-8 py-4 bg-ps-blue text-black rounded-lg font-black uppercase tracking-[0.2em] text-[11px] z-50 flex items-center space-x-3 border border-ps-yellow/30 shadow-[0_0_50px_rgba(0,240,255,0.35)] animate-bounce hover:scale-105 active:scale-95 transition-transform"
         >
           <ChevronDown className="w-5 h-5" />
           <span>{t("logs.new_activity_btn", "New Activity Below")}</span>

--- a/frontend/src/components/views/ManageSourcesView.jsx
+++ b/frontend/src/components/views/ManageSourcesView.jsx
@@ -6,6 +6,7 @@ import {
 import { QRCodeSVG } from 'qrcode.react'
 import { useTranslation } from 'react-i18next'
 import { cn, isPS5 } from '../../utils/helpers'
+import HudButton from '../ui/HudButton'
 
 const ManageSourcesView = ({ onBack, ip, addToast, showConfirm }) => {
   const { t } = useTranslation()
@@ -94,15 +95,17 @@ const ManageSourcesView = ({ onBack, ip, addToast, showConfirm }) => {
   if (isPS5) {
     return (
       <div className="max-w-3xl mx-auto space-y-12 pb-20">
-        <div className="flex items-center space-x-6">
-          <button
+        <div className="flex items-center space-x-4 md:space-x-6">
+          <HudButton
             onClick={onBack}
-            className="p-4 rounded-2xl bg-white/5 hover:bg-white/10 transition-all border border-white/10"
-          >
-            <ArrowLeft className="w-7 h-7" />
-          </button>
+            icon={ArrowLeft}
+            variant="secondary"
+            size="sm"
+            className="cp-btn--icon"
+            aria-label={t("manage_sources.back", "Back")}
+          />
           <h2 className="text-4xl font-extrabold text-white tracking-tight">
-            {t("manage_sources.ps5_title_1", "Manage")} <span className="text-ps-blue">{t("manage_sources.ps5_title_2", "Sources")}</span>
+            {t("manage_sources.ps5_title_1", "Manage")} <span className="cp-title-accent">{t("manage_sources.ps5_title_2", "Sources")}</span>
           </h2>
         </div>
 
@@ -125,15 +128,17 @@ const ManageSourcesView = ({ onBack, ip, addToast, showConfirm }) => {
   return (
     <div className="w-full max-w-3xl mx-auto space-y-10 pb-20 min-w-0">
       {/* Header */}
-      <div className="flex items-center space-x-6">
-        <button
+      <div className="flex items-center space-x-4 md:space-x-6">
+        <HudButton
           onClick={onBack}
-          className="p-4 rounded-2xl bg-white/5 hover:bg-white/10 transition-all border border-white/10"
-        >
-          <ArrowLeft className="w-7 h-7" />
-        </button>
+          icon={ArrowLeft}
+          variant="secondary"
+          size="sm"
+          className="cp-btn--icon"
+          aria-label={t("manage_sources.back", "Back")}
+        />
         <h2 className="text-4xl font-extrabold text-white tracking-tight">
-          {t("manage_sources.web_title_1", "Payload")} <span className="text-ps-blue">{t("manage_sources.web_title_2", "Sources")}</span>
+          {t("manage_sources.web_title_1", "Payload")} <span className="cp-title-accent">{t("manage_sources.web_title_2", "Sources")}</span>
         </h2>
       </div>
       {/* Sources list */}
@@ -182,29 +187,9 @@ const ManageSourcesView = ({ onBack, ip, addToast, showConfirm }) => {
                 <div className="flex items-center space-x-2 shrink-0 lg:hidden">
                   {src.removable && (
                     <>
-                      <button
-                        onClick={() => move(idx, -1)}
-                        disabled={idx <= 1}
-                        className="p-2 rounded-xl bg-white/5 hover:bg-white/10 disabled:opacity-20 disabled:cursor-not-allowed transition-all"
-                        title={t("manage_sources.move_up_btn", "Move up")}
-                      >
-                        <ChevronUp className="w-4 h-4" />
-                      </button>
-                      <button
-                        onClick={() => move(idx, 1)}
-                        disabled={idx === sources.length - 1}
-                        className="p-2 rounded-xl bg-white/5 hover:bg-white/10 disabled:opacity-20 disabled:cursor-not-allowed transition-all"
-                        title={t("manage_sources.move_down_btn", "Move down")}
-                      >
-                        <ChevronDown className="w-4 h-4" />
-                      </button>
-                      <button
-                        onClick={() => remove(idx)}
-                        className="p-2 rounded-xl bg-red-950/20 text-red-500 border border-red-500/10 hover:bg-red-500 hover:text-white transition-all"
-                        title={t("manage_sources.remove_btn", "Remove source")}
-                      >
-                        <Trash2 className="w-4 h-4" />
-                      </button>
+                      <HudButton onClick={() => move(idx, -1)} disabled={idx <= 1} icon={ChevronUp} variant="secondary" size="sm" className="cp-btn--icon" title={t("manage_sources.move_up_btn", "Move up")} />
+                      <HudButton onClick={() => move(idx, 1)} disabled={idx === sources.length - 1} icon={ChevronDown} variant="secondary" size="sm" className="cp-btn--icon" title={t("manage_sources.move_down_btn", "Move down")} />
+                      <HudButton onClick={() => remove(idx)} icon={Trash2} variant="dangerSoft" size="sm" className="cp-btn--icon" title={t("manage_sources.remove_btn", "Remove source")} />
                     </>
                   )}
                   {!src.removable && (
@@ -235,29 +220,9 @@ const ManageSourcesView = ({ onBack, ip, addToast, showConfirm }) => {
               <div className="hidden lg:flex items-center space-x-2 shrink-0">
                 {src.removable && (
                   <>
-                    <button
-                      onClick={() => move(idx, -1)}
-                      disabled={idx <= 1}
-                      className="p-2 rounded-xl bg-white/5 hover:bg-white/10 disabled:opacity-20 disabled:cursor-not-allowed transition-all"
-                      title={t("manage_sources.move_up_btn", "Move up")}
-                    >
-                      <ChevronUp className="w-4 h-4" />
-                    </button>
-                    <button
-                      onClick={() => move(idx, 1)}
-                      disabled={idx === sources.length - 1}
-                      className="p-2 rounded-xl bg-white/5 hover:bg-white/10 disabled:opacity-20 disabled:cursor-not-allowed transition-all"
-                      title={t("manage_sources.move_down_btn", "Move down")}
-                    >
-                      <ChevronDown className="w-4 h-4" />
-                    </button>
-                    <button
-                      onClick={() => remove(idx)}
-                      className="p-2 rounded-xl bg-red-950/20 text-red-500 border border-red-500/10 hover:bg-red-500 hover:text-white transition-all"
-                      title={t("manage_sources.remove_btn", "Remove source")}
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </button>
+                    <HudButton onClick={() => move(idx, -1)} disabled={idx <= 1} icon={ChevronUp} variant="secondary" size="sm" className="cp-btn--icon" title={t("manage_sources.move_up_btn", "Move up")} />
+                    <HudButton onClick={() => move(idx, 1)} disabled={idx === sources.length - 1} icon={ChevronDown} variant="secondary" size="sm" className="cp-btn--icon" title={t("manage_sources.move_down_btn", "Move down")} />
+                    <HudButton onClick={() => remove(idx)} icon={Trash2} variant="dangerSoft" size="sm" className="cp-btn--icon" title={t("manage_sources.remove_btn", "Remove source")} />
                   </>
                 )}
                 {!src.removable && (
@@ -273,13 +238,15 @@ const ManageSourcesView = ({ onBack, ip, addToast, showConfirm }) => {
 
       {/* Add Source */}
       {!showAddForm ? (
-        <button
+        <HudButton
           onClick={() => { setShowAddForm(true); setAddError('') }}
-          className="w-full flex items-center justify-center space-x-3 py-5 border-2 border-dashed border-white/10 rounded-2xl text-zinc-500 hover:text-ps-blue hover:border-ps-blue/30 transition-all font-bold"
+          icon={Plus}
+          variant="ghost"
+          block
+          className="cp-btn--bar"
         >
-          <Plus className="w-5 h-5" />
-          <span>{t("manage_sources.add_source_btn", "Add Source")}</span>
-        </button>
+          {t("manage_sources.add_source_btn", "Add Source")}
+        </HudButton>
       ) : (
         <form onSubmit={handleAdd} className="p-6 glass-card rounded-2xl border border-white/10 space-y-4">
           <p className="font-bold text-white text-lg">{t("manage_sources.add_new_title", "Add a New Source")}</p>
@@ -297,22 +264,24 @@ const ManageSourcesView = ({ onBack, ip, addToast, showConfirm }) => {
               disabled={adding}
             />
             <div className="flex gap-3 w-full lg:w-auto">
-              <button
+              <HudButton
                 type="submit"
                 disabled={adding || !newUrl.trim()}
-                className="flex-1 md:flex-initial flex items-center justify-center space-x-2 px-6 py-3 bg-ps-blue hover:bg-ps-blue/80 disabled:opacity-50 text-white rounded-xl font-bold transition-all whitespace-nowrap"
+                icon={adding ? Loader2 : Plus}
+                variant="primary"
+                className="flex-1 md:flex-initial"
               >
-                {adding ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
-                <span>{adding ? t("manage_sources.validating", "Validating...") : t("manage_sources.add_btn", "Add")}</span>
-              </button>
-              <button
+                {adding ? t("manage_sources.validating", "Validating...") : t("manage_sources.add_btn", "Add")}
+              </HudButton>
+              <HudButton
                 type="button"
                 onClick={() => { setShowAddForm(false); setNewUrl(''); setAddError('') }}
                 disabled={adding}
-                className="flex-1 md:flex-initial px-5 py-3 bg-white/5 hover:bg-white/10 text-white rounded-xl font-bold transition-all text-center whitespace-nowrap"
+                variant="secondary"
+                className="flex-1 md:flex-initial"
               >
                 {t("manage_sources.cancel_btn", "Cancel")}
-              </button>
+              </HudButton>
             </div>
           </div>
           {addError && (

--- a/frontend/src/components/views/MoveFromUsbView.jsx
+++ b/frontend/src/components/views/MoveFromUsbView.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { ArrowLeft, HardDrive, Cpu, AlertTriangle, CheckCircle2, Loader2, Info, Usb } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '../../utils/helpers'
+import HudButton from '../ui/HudButton'
 
 const MoveFromUsbView = ({ path, onBack, onComplete, addToast }) => {
   const { t } = useTranslation()
@@ -94,7 +95,9 @@ const MoveFromUsbView = ({ path, onBack, onComplete, addToast }) => {
             <div className="space-y-2">
               <p className="text-lg font-bold text-white">{t("move_usb.error_title", "Something went wrong")}</p>
               <p className="text-red-400/80 leading-relaxed">{errorMsg}</p>
-              <button onClick={checkPayload} className="mt-4 px-6 py-2 bg-red-500 text-white rounded-xl font-bold text-sm">{t("move_usb.retry_btn", "Retry")}</button>
+              <HudButton onClick={checkPayload} variant="danger" size="sm" className="mt-4">
+                {t("move_usb.retry_btn", "Retry")}
+              </HudButton>
             </div>
           </div>
         )}
@@ -110,7 +113,9 @@ const MoveFromUsbView = ({ path, onBack, onComplete, addToast }) => {
                 </p>
               </div>
             </div>
-            <button onClick={onBack} className="w-full py-4 md:py-6 rounded-2xl bg-white/5 hover:bg-white/10 text-white font-black uppercase italic text-lg md:text-xl transition-all border border-white/10">{t("move_usb.return_btn", "Return to Storage Hub")}</button>
+            <HudButton onClick={onBack} variant="secondary" size="lg" block className="cp-btn--bar">
+              {t("move_usb.return_btn", "Return to Storage Hub")}
+            </HudButton>
           </div>
         )}
 
@@ -126,10 +131,16 @@ const MoveFromUsbView = ({ path, onBack, onComplete, addToast }) => {
               </div>
             </div>
             <div className="flex flex-col sm:flex-row gap-4">
-              <button onClick={onBack} className="flex-1 py-4 md:py-6 rounded-2xl bg-white/5 hover:bg-white/10 text-white font-bold uppercase transition-all">{t("move_usb.cancel_btn", "Cancel")}</button>
+              <HudButton onClick={onBack} variant="secondary" size="lg" className="flex-1">
+                {t("move_usb.cancel_btn", "Cancel")}
+              </HudButton>
               <div className="flex flex-1 gap-2">
-                <button onClick={() => performMove(true, true)} className="flex-1 py-4 md:py-6 rounded-2xl bg-ps-blue/50 hover:bg-ps-blue/70 text-white font-black uppercase italic text-sm md:text-lg transition-all border border-ps-blue/30">{t("move_usb.overwrite_copy_btn", "Overwrite & Copy")}</button>
-                <button onClick={() => performMove(true, false)} className="flex-1 py-4 md:py-6 rounded-2xl bg-ps-blue hover:bg-ps-blue/80 text-white font-black uppercase italic text-sm md:text-lg transition-all shadow-xl shadow-ps-blue/20">{t("move_usb.overwrite_move_btn", "Overwrite & Move")}</button>
+                <HudButton onClick={() => performMove(true, true)} variant="ghost" size="lg" className="flex-1">
+                  {t("move_usb.overwrite_copy_btn", "Overwrite & Copy")}
+                </HudButton>
+                <HudButton onClick={() => performMove(true, false)} variant="primary" size="lg" className="flex-1">
+                  {t("move_usb.overwrite_move_btn", "Overwrite & Move")}
+                </HudButton>
               </div>
             </div>
           </div>
@@ -147,8 +158,12 @@ const MoveFromUsbView = ({ path, onBack, onComplete, addToast }) => {
               </div>
             </div>
             <div className="flex flex-col sm:flex-row gap-4">
-              <button onClick={() => performMove(false, true)} className="flex-1 py-4 md:py-6 rounded-2xl bg-white/10 hover:bg-white/20 text-white font-black uppercase italic text-lg md:text-xl transition-all border border-white/20">{t("move_usb.copy_btn", "Copy to Internal")}</button>
-              <button onClick={() => performMove(false, false)} className="flex-1 py-4 md:py-6 rounded-2xl bg-ps-blue hover:bg-ps-blue/80 text-white font-black uppercase italic text-lg md:text-xl transition-all shadow-2xl shadow-ps-blue/30">{t("move_usb.move_btn", "Move to Internal")}</button>
+              <HudButton onClick={() => performMove(false, true)} variant="secondary" size="lg" className="flex-1">
+                {t("move_usb.copy_btn", "Copy to Internal")}
+              </HudButton>
+              <HudButton onClick={() => performMove(false, false)} variant="primary" size="lg" className="flex-1">
+                {t("move_usb.move_btn", "Move to Internal")}
+              </HudButton>
             </div>
           </div>
         )}

--- a/frontend/src/components/views/SettingsView.jsx
+++ b/frontend/src/components/views/SettingsView.jsx
@@ -134,35 +134,38 @@ const SettingsView = ({ config, onSaveConfig, setShowLogs, onNavigate }) => {
 
       {/* Startup Settings */}
       <section className="space-y-8">
-        <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-6 min-w-0 [&>*]:min-w-0">
           <SettingRow
             title={t("settings.language_title", "Language")}
             description={t("settings.language_desc", "Change the display language of the application.")}
             icon={Languages}
             vertical
           >
-            <div className="flex flex-col items-start space-y-2 w-full">
-              <div className="relative w-full bg-black/50 border border-white/10 text-white rounded-xl px-4 py-3 font-bold tracking-tight hover:bg-white/5 transition-all overflow-hidden flex items-center justify-between">
-                <span>
+            <div className="flex flex-col items-stretch gap-2 w-full min-w-0 max-w-full">
+              <div className="cp-lang-select">
+                <span className="cp-lang-select__label">
                   {followBrowserLanguage
                     ? t("settings.language_system_default", "System Default")
                     : getLanguageDisplayName(currentLang)}
                 </span>
-                <ChevronRight className="w-5 h-5 text-zinc-500 rotate-90" />
+                <ChevronRight className="cp-lang-select__chevron" aria-hidden />
                 <select
                   value={selectedLanguage}
                   onChange={handleLanguageChange}
-                  className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
+                  className="cp-lang-select__native"
+                  aria-label={t("settings.language_title", "Language")}
                 >
                   <option value={FOLLOW_BROWSER_LANGUAGE} className="bg-[#121214]">
                     {t("settings.language_system_default", "System Default")}
                   </option>
-                  {Object.keys(i18n.store.data).map(lang => (
-                    <option key={lang} value={lang} className="bg-[#121214]">{getLanguageDisplayName(lang)}</option>
+                  {Object.keys(i18n.store.data).map((lang) => (
+                    <option key={lang} value={lang} className="bg-[#121214]">
+                      {getLanguageDisplayName(lang)}
+                    </option>
                   ))}
                 </select>
               </div>
-              <p className="text-sm text-zinc-500 leading-relaxed text-left w-full mt-1">
+              <p className="text-sm text-zinc-500 leading-relaxed text-left w-full min-w-0">
                 {t("settings.language_disclaimer", "Translations are community-driven and may contain errors.")}
               </p>
             </div>

--- a/frontend/src/components/views/SettingsView.jsx
+++ b/frontend/src/components/views/SettingsView.jsx
@@ -1,7 +1,9 @@
 import React, { useState } from 'react'
-import { Terminal, ChevronRight, Globe, Languages } from 'lucide-react'
+import { Terminal, ChevronRight, Globe, Languages, Palette } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { cn } from '../../utils/helpers'
+import { useTheme } from '../../theme/ThemeContext'
+import ToggleSwitch from '../ui/ToggleSwitch'
 
 const FOLLOW_BROWSER_LANGUAGE = '__auto__'
 
@@ -42,6 +44,7 @@ const SettingRow = ({ title, description, children, icon: Icon, vertical }) => (
 
 const SettingsView = ({ config, onSaveConfig, setShowLogs, onNavigate }) => {
   const { t, i18n } = useTranslation()
+  const { themeId, setThemeId, themes } = useTheme()
   const autoOpen = config.AUTO_BROWSER_OPEN !== false
   const autoInstall = config.AUTO_INSTALL_APP !== false
   const autoloadDelay = config.AUTOLOAD_DELAY || 5
@@ -88,6 +91,44 @@ const SettingsView = ({ config, onSaveConfig, setShowLogs, onNavigate }) => {
         </h2>
       </div>
 
+      {/* Appearance / theme */}
+      <section className="space-y-8">
+        <h3 className="label-caps !text-ps-blue !opacity-100 flex items-center space-x-4 text-xl tracking-[0.2em]">
+          <Palette className="w-6 h-6" />
+          <span>{t("settings.appearance_title", "Appearance")}</span>
+        </h3>
+        <div className="cp-theme-grid">
+          {Object.values(themes).map((th) => (
+            <button
+              key={th.id}
+              type="button"
+              onClick={() => setThemeId(th.id)}
+              className={cn('cp-theme-card', themeId === th.id && 'is-active')}
+            >
+              <div className="cp-theme-card__swatches">
+                {th.id === 'cyberpunk' ? (
+                  <>
+                    <span className="cp-theme-card__swatch" style={{ background: '#ff3c3c' }} />
+                    <span className="cp-theme-card__swatch" style={{ background: '#00f0ff' }} />
+                    <span className="cp-theme-card__swatch" style={{ background: '#fcee0a' }} />
+                    <span className="cp-theme-card__swatch" style={{ background: '#0a0508' }} />
+                  </>
+                ) : (
+                  <>
+                    <span className="cp-theme-card__swatch" style={{ background: '#0095ff' }} />
+                    <span className="cp-theme-card__swatch" style={{ background: '#101014' }} />
+                    <span className="cp-theme-card__swatch" style={{ background: '#ffffff' }} />
+                    <span className="cp-theme-card__swatch" style={{ background: '#08080a' }} />
+                  </>
+                )}
+              </div>
+              <div className="cp-theme-card__name">{th.label}</div>
+              <div className="cp-theme-card__desc">{th.description}</div>
+            </button>
+          ))}
+        </div>
+      </section>
+
       {/* Startup Settings */}
       <section className="space-y-8">
         <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
@@ -128,72 +169,40 @@ const SettingsView = ({ config, onSaveConfig, setShowLogs, onNavigate }) => {
             title={t("settings.auto_open_title", "Auto-open Browser")}
             description={t("settings.auto_open_desc", "Automatically launch the browser when Payload Manager payload is executed.")}
           >
-            <button
-              onClick={() => onSaveConfig({ AUTO_BROWSER_OPEN: !autoOpen })}
-              className={cn(
-                "w-14 h-7 md:w-20 md:h-10 rounded-full transition-all relative p-1 md:p-1.5",
-                autoOpen ? "bg-ps-blue" : "bg-white/10"
-              )}
-            >
-              <div className={cn(
-                "w-5 h-5 md:w-7 md:h-7 bg-white rounded-full transition-all",
-                autoOpen ? "translate-x-7 md:translate-x-10" : "translate-x-0"
-              )} />
-            </button>
+            <ToggleSwitch
+              on={autoOpen}
+              onChange={(v) => onSaveConfig({ AUTO_BROWSER_OPEN: v })}
+            />
           </SettingRow>
 
           <SettingRow
             title={t("settings.auto_install_title", "Auto-install App Launcher")}
             description={t("settings.auto_install_desc", "Automatically install the Payload Manager app to the PS5 home screen.")}
           >
-            <button
-              onClick={() => onSaveConfig({ AUTO_INSTALL_APP: !autoInstall })}
-              className={cn(
-                "w-14 h-7 md:w-20 md:h-10 rounded-full transition-all relative p-1 md:p-1.5",
-                autoInstall ? "bg-ps-blue" : "bg-white/10"
-              )}
-            >
-              <div className={cn(
-                "w-5 h-5 md:w-7 md:h-7 bg-white rounded-full transition-all",
-                autoInstall ? "translate-x-7 md:translate-x-10" : "translate-x-0"
-              )} />
-            </button>
+            <ToggleSwitch
+              on={autoInstall}
+              onChange={(v) => onSaveConfig({ AUTO_INSTALL_APP: v })}
+            />
           </SettingRow>
 
           <SettingRow
             title={t("settings.kill_disc_title", "Kill Disc Player")}
             description={t("settings.kill_disc_desc", "Automatically terminate the Disc Player application on startup (for BD-JB users).")}
           >
-            <button
-              onClick={() => onSaveConfig({ KILL_DISC_PLAYER_ON_STARTUP: !config.KILL_DISC_PLAYER_ON_STARTUP })}
-              className={cn(
-                "w-14 h-7 md:w-20 md:h-10 rounded-full transition-all relative p-1 md:p-1.5",
-                config.KILL_DISC_PLAYER_ON_STARTUP !== false ? "bg-ps-blue" : "bg-white/10"
-              )}
-            >
-              <div className={cn(
-                "w-5 h-5 md:w-7 md:h-7 bg-white rounded-full transition-all",
-                config.KILL_DISC_PLAYER_ON_STARTUP !== false ? "translate-x-7 md:translate-x-10" : "translate-x-0"
-              )} />
-            </button>
+            <ToggleSwitch
+              on={config.KILL_DISC_PLAYER_ON_STARTUP !== false}
+              onChange={(v) => onSaveConfig({ KILL_DISC_PLAYER_ON_STARTUP: v })}
+            />
           </SettingRow>
 
           <SettingRow
             title={t("settings.scan_usb_title", "Scan USB Payloads")}
             description={t("settings.scan_usb_desc", "Enable scanning for .elf and .bin files in the root directory of USB drives (/mnt/usb0-7).")}
           >
-            <button
-              onClick={() => onSaveConfig({ SCAN_USB_PAYLOADS: !config.SCAN_USB_PAYLOADS })}
-              className={cn(
-                "w-14 h-7 md:w-20 md:h-10 rounded-full transition-all relative p-1 md:p-1.5",
-                config.SCAN_USB_PAYLOADS ? "bg-ps-blue" : "bg-white/10"
-              )}
-            >
-              <div className={cn(
-                "w-5 h-5 md:w-7 md:h-7 bg-white rounded-full transition-all",
-                config.SCAN_USB_PAYLOADS ? "translate-x-7 md:translate-x-10" : "translate-x-0"
-              )} />
-            </button>
+            <ToggleSwitch
+              on={!!config.SCAN_USB_PAYLOADS}
+              onChange={(v) => onSaveConfig({ SCAN_USB_PAYLOADS: v })}
+            />
           </SettingRow>
 
           <div className="flex flex-col justify-between p-8 bg-white/[0.03] rounded-3xl border border-white/10 space-y-8 h-full">
@@ -238,18 +247,10 @@ const SettingsView = ({ config, onSaveConfig, setShowLogs, onNavigate }) => {
             description={t("settings.multi_sources_desc", "Enable third-party payload repositories. Payloads from multiple sources are grouped by catalog in the Manage tab.")}
             icon={Globe}
           >
-            <button
-              onClick={() => onSaveConfig({ MULTI_SOURCES_ENABLED: !multiSources })}
-              className={cn(
-                "w-14 h-7 md:w-20 md:h-10 rounded-full transition-all relative p-1 md:p-1.5",
-                multiSources ? "bg-ps-blue" : "bg-white/10"
-              )}
-            >
-              <div className={cn(
-                "w-5 h-5 md:w-7 md:h-7 bg-white rounded-full transition-all",
-                multiSources ? "translate-x-7 md:translate-x-10" : "translate-x-0"
-              )} />
-            </button>
+            <ToggleSwitch
+              on={multiSources}
+              onChange={(v) => onSaveConfig({ MULTI_SOURCES_ENABLED: v })}
+            />
           </SettingRow>
 
           {multiSources && (

--- a/frontend/src/components/views/SettingsView.jsx
+++ b/frontend/src/components/views/SettingsView.jsx
@@ -109,21 +109,21 @@ const SettingsView = ({ config, onSaveConfig, setShowLogs, onNavigate }) => {
               className={cn('cp-theme-card', themeId === th.id && 'is-active')}
             >
               <div className="cp-theme-card__swatches">
-                {th.id === 'cyberpunk' ? (
-                  <>
-                    <span className="cp-theme-card__swatch" style={{ background: '#ff3c3c' }} />
-                    <span className="cp-theme-card__swatch" style={{ background: '#00f0ff' }} />
-                    <span className="cp-theme-card__swatch" style={{ background: '#fcee0a' }} />
-                    <span className="cp-theme-card__swatch" style={{ background: '#0a0508' }} />
-                  </>
-                ) : (
-                  <>
-                    <span className="cp-theme-card__swatch" style={{ background: '#0095ff' }} />
-                    <span className="cp-theme-card__swatch" style={{ background: '#101014' }} />
-                    <span className="cp-theme-card__swatch" style={{ background: '#ffffff' }} />
-                    <span className="cp-theme-card__swatch" style={{ background: '#08080a' }} />
-                  </>
-                )}
+                {(th.swatches?.length
+                  ? th.swatches.slice(0, 4)
+                  : [
+                      th.vars?.['--color-ps-blue'] || '#0095ff',
+                      th.vars?.['--color-ps-surface'] || '#101014',
+                      th.vars?.['--color-text'] || '#ffffff',
+                      th.vars?.['--color-ps-black'] || '#08080a',
+                    ]
+                ).map((color, i) => (
+                  <span
+                    key={`${th.id}-swatch-${i}`}
+                    className="cp-theme-card__swatch"
+                    style={{ background: color }}
+                  />
+                ))}
               </div>
               <div className="cp-theme-card__name">{th.label}</div>
               <div className="cp-theme-card__desc">{th.description}</div>

--- a/frontend/src/components/views/SettingsView.jsx
+++ b/frontend/src/components/views/SettingsView.jsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { cn } from '../../utils/helpers'
 import { useTheme } from '../../theme/ThemeContext'
 import ToggleSwitch from '../ui/ToggleSwitch'
+import HudButton from '../ui/HudButton'
 
 const FOLLOW_BROWSER_LANGUAGE = '__auto__'
 
@@ -15,30 +16,32 @@ const isFollowingBrowserLanguage = () => {
   }
 }
 
+/**
+ * Settings card: icon | copy | control.
+ * Uses a real 3-col grid so the cyberpunk OFF|ON toggle never collapses
+ * the title into a single-word column.
+ */
 const SettingRow = ({ title, description, children, icon: Icon, vertical }) => (
-  <div className={cn(
-    "p-5 md:p-8 bg-white/[0.03] rounded-3xl border border-white/10 hover:border-ps-blue/30 transition-all group h-full",
-    vertical ? "flex flex-col space-y-4" : "grid grid-cols-[1fr_auto] gap-x-4 gap-y-3 md:flex md:items-center md:justify-between md:gap-6"
-  )}>
-    <div className="flex items-start md:items-center space-x-4 md:space-x-6 min-w-0 col-span-1">
-      {Icon && (
-        <div className="p-3 md:p-4 bg-white/5 rounded-2xl group-hover:bg-ps-blue/10 transition-colors shrink-0">
-          <Icon className="w-5 h-5 md:w-6 md:h-6 text-zinc-500 group-hover:text-ps-blue transition-colors" />
-        </div>
-      )}
-      <div className="space-y-1 min-w-0">
-        <p className="font-bold text-white uppercase text-base md:text-lg tracking-tight leading-tight">{title}</p>
-        <p className={cn("text-sm text-zinc-500 max-w-md leading-relaxed", vertical ? "block mt-2" : "hidden md:!block")}>{description}</p>
+  <div
+    className={cn(
+      'setting-row group',
+      vertical && 'setting-row--vertical'
+    )}
+  >
+    {Icon && (
+      <div className="setting-row__icon">
+        <Icon className="w-5 h-5 md:w-6 md:h-6" />
       </div>
+    )}
+    <div className="setting-row__copy">
+      <p className="setting-row__title">{title}</p>
+      {description && (
+        <p className="setting-row__desc">{description}</p>
+      )}
     </div>
-    <div className={cn("shrink-0", vertical ? "w-full pt-2" : "col-start-2 row-start-1 md:ml-8 self-center md:self-auto")}>
+    <div className="setting-row__control">
       {children}
     </div>
-    {!vertical && (
-      <p className="md:hidden col-span-2 text-xs text-zinc-500 leading-relaxed">
-        {description}
-      </p>
-    )}
   </div>
 )
 
@@ -205,29 +208,26 @@ const SettingsView = ({ config, onSaveConfig, setShowLogs, onNavigate }) => {
             />
           </SettingRow>
 
-          <div className="flex flex-col justify-between p-8 bg-white/[0.03] rounded-3xl border border-white/10 space-y-8 h-full">
-            <div className="flex justify-between items-center">
-              <div className="space-y-1">
-                <p className="font-bold text-white uppercase text-lg tracking-tight">{t("settings.autoload_delay_title", "Autoload Delay")}</p>
-                <p className="text-sm text-zinc-500">{t("settings.autoload_delay_desc", "Wait time before the autoload sequence begins.")}</p>
+          <div className="cp-delay-card">
+            <div className="cp-delay-card__head">
+              <div className="min-w-0 space-y-1">
+                <p className="setting-row__title">{t("settings.autoload_delay_title", "Autoload Delay")}</p>
+                <p className="setting-row__desc">{t("settings.autoload_delay_desc", "Wait time before the autoload sequence begins.")}</p>
               </div>
-              <span className="text-ps-blue font-black text-4xl italic tracking-tighter">{autoloadDelay}s</span>
+              <span className="cp-delay-card__value">{autoloadDelay}s</span>
             </div>
-
-            <div className="grid grid-cols-3 gap-4">
-              {[3, 5, 10].map(s => (
-                <button
+            <div className="cp-delay-card__chips">
+              {[3, 5, 10].map((s) => (
+                <HudButton
                   key={s}
                   onClick={() => onSaveConfig({ AUTOLOAD_DELAY: s })}
-                  className={cn(
-                    "py-5 rounded-2xl font-black text-xl transition-all border uppercase italic",
-                    autoloadDelay === s
-                      ? "bg-ps-blue border-ps-blue text-white scale-[1.02]"
-                      : "bg-white/5 border-white/10 text-zinc-500 hover:bg-white/10 hover:text-white"
-                  )}
+                  variant={autoloadDelay === s ? 'primary' : 'secondary'}
+                  size="lg"
+                  block
+                  className={cn(autoloadDelay === s && 'cp-btn--selected is-selected')}
                 >
                   {s}s
-                </button>
+                </HudButton>
               ))}
             </div>
           </div>
@@ -255,24 +255,20 @@ const SettingsView = ({ config, onSaveConfig, setShowLogs, onNavigate }) => {
 
           {multiSources && (
             <button
+              type="button"
               onClick={() => onNavigate('sources')}
-              className="group w-full text-left grid grid-cols-[1fr_auto] md:flex md:items-center md:justify-between p-5 md:p-8 bg-white/[0.03] rounded-3xl border border-white/10 hover:border-ps-blue/50 hover:bg-ps-blue/5 transition-all gap-x-4 gap-y-3 md:gap-6"
+              className="setting-row group w-full text-left cursor-pointer hover:border-ps-blue/50"
             >
-              <div className="flex items-start md:items-center space-x-4 md:space-x-6 min-w-0 col-span-1">
-                <div className="p-3 md:p-4 bg-white/5 rounded-2xl group-hover:bg-ps-blue/10 transition-colors shrink-0">
-                  <Globe className="w-5 h-5 md:w-6 md:h-6 text-zinc-500 group-hover:text-ps-blue transition-colors" />
-                </div>
-                <div className="space-y-1 min-w-0">
-                  <p className="font-bold text-white uppercase text-base md:text-lg tracking-tight leading-tight">{t("settings.manage_sources_title", "Manage Sources")}</p>
-                  <p className="hidden md:!block text-sm text-zinc-500 max-w-md leading-relaxed">{t("settings.manage_sources_desc", "Add, remove, or reorder your payload repositories.")}</p>
-                </div>
+              <div className="setting-row__icon">
+                <Globe className="w-5 h-5 md:w-6 md:h-6" />
               </div>
-              <div className="shrink-0 col-start-2 row-start-1 md:ml-8 self-center md:self-auto">
-                <ChevronRight className="w-6 h-6 md:w-8 md:h-8 text-zinc-700 group-hover:text-ps-blue group-hover:translate-x-2 transition-all" />
+              <div className="setting-row__copy">
+                <p className="setting-row__title">{t("settings.manage_sources_title", "Manage Sources")}</p>
+                <p className="setting-row__desc">{t("settings.manage_sources_desc", "Add, remove, or reorder your payload repositories.")}</p>
               </div>
-              <p className="md:hidden col-span-2 text-xs text-zinc-500 leading-relaxed">
-                {t("settings.manage_sources_desc", "Add, remove, or reorder your payload repositories.")}
-              </p>
+              <div className="setting-row__control">
+                <ChevronRight className="w-6 h-6 md:w-8 md:h-8 text-zinc-600 group-hover:text-ps-blue group-hover:translate-x-1 transition-all" />
+              </div>
             </button>
           )}
         </div>
@@ -286,24 +282,20 @@ const SettingsView = ({ config, onSaveConfig, setShowLogs, onNavigate }) => {
         </h3>
 
         <button
+          type="button"
           onClick={() => setShowLogs(true)}
-          className="group w-full text-left grid grid-cols-[1fr_auto] md:flex md:items-center md:justify-between p-5 md:p-8 bg-white/[0.03] rounded-3xl border border-white/10 hover:border-ps-blue/50 hover:bg-ps-blue/5 transition-all gap-x-4 gap-y-3 md:gap-6"
+          className="setting-row group w-full text-left cursor-pointer hover:border-ps-blue/50"
         >
-          <div className="flex items-start md:items-center space-x-4 md:space-x-6 min-w-0 col-span-1">
-            <div className="p-3 md:p-4 bg-white/5 rounded-2xl group-hover:bg-ps-blue/10 transition-colors shrink-0">
-              <Terminal className="w-5 h-5 md:w-6 md:h-6 text-zinc-500 group-hover:text-ps-blue transition-colors" />
-            </div>
-            <div className="space-y-1 min-w-0">
-              <p className="font-bold text-white uppercase text-base md:text-lg tracking-tight leading-tight">{t("settings.log_viewer_title", "Open Log Viewer")}</p>
-              <p className="hidden md:!block text-sm text-zinc-500 max-w-md leading-relaxed">{t("settings.log_viewer_desc", "Access real-time debug output from the Payload Manager daemon.")}</p>
-            </div>
+          <div className="setting-row__icon">
+            <Terminal className="w-5 h-5 md:w-6 md:h-6" />
           </div>
-          <div className="shrink-0 col-start-2 row-start-1 md:ml-8 self-center md:self-auto">
-            <ChevronRight className="w-6 h-6 md:w-8 md:h-8 text-zinc-700 group-hover:text-ps-blue group-hover:translate-x-2 transition-all" />
+          <div className="setting-row__copy">
+            <p className="setting-row__title">{t("settings.log_viewer_title", "Open Log Viewer")}</p>
+            <p className="setting-row__desc">{t("settings.log_viewer_desc", "Access real-time debug output from the Payload Manager daemon.")}</p>
           </div>
-          <p className="md:hidden col-span-2 text-xs text-zinc-500 leading-relaxed">
-            {t("settings.log_viewer_desc", "Access real-time debug output from the Payload Manager daemon.")}
-          </p>
+          <div className="setting-row__control">
+            <ChevronRight className="w-6 h-6 md:w-8 md:h-8 text-zinc-600 group-hover:text-ps-blue group-hover:translate-x-1 transition-all" />
+          </div>
         </button>
       </section>
 

--- a/frontend/src/components/views/StorageHub.jsx
+++ b/frontend/src/components/views/StorageHub.jsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { QRCodeSVG } from 'qrcode.react'
 import { cn, isPS5, isIOS, parsePayloadName } from '../../utils/helpers'
 import PayloadName from '../ui/PayloadName'
+import HudButton from '../ui/HudButton'
 
 const PayloadItem = ({ p, multiSources, isPS5, onInstall, srcId, srcUrl }) => {
   const { t } = useTranslation()
@@ -23,19 +24,15 @@ const PayloadItem = ({ p, multiSources, isPS5, onInstall, srcId, srcUrl }) => {
         <p className="text-sm md:text-base text-zinc-400 font-medium leading-relaxed">{p.description}</p>
       )}
     </div>
-    <button
+    <HudButton
       onClick={() => onInstall(p, srcId === 'legacy-repo' ? null : srcId, srcUrl)}
-      className={cn(
-        "flex items-center justify-center space-x-3 px-6 md:px-8 py-3 md:py-5 rounded-2xl font-bold text-lg transition-all shrink-0 transform active:scale-95",
-        isPS5 ? "w-auto px-12" : "w-full md:w-auto",
-        p.isUpdate
-          ? "bg-emerald-600 hover:bg-emerald-500 text-white"
-          : "bg-ps-blue hover:bg-ps-blue/80 text-white"
-      )}
+      icon={CloudDownload}
+      variant={p.isUpdate ? 'success' : 'primary'}
+      size="lg"
+      className={cn('shrink-0', !isPS5 && 'w-full md:w-auto')}
     >
-      <CloudDownload className="w-5 h-5 md:w-6 md:h-6" />
-      <span>{p.isUpdate ? t("storage_hub.update_btn", "Update") : t("storage_hub.install_btn", "Install")}</span>
-    </button>
+      {p.isUpdate ? t("storage_hub.update_btn", "Update") : t("storage_hub.install_btn", "Install")}
+    </HudButton>
   </div>
 )
 }
@@ -201,9 +198,9 @@ const StorageHub = ({ payloads, payloadMeta, onInstall, onDelete, onUpload, onIm
         </h2>
 
         {!isPS5 && (
-          <label className="inline-flex items-center space-x-4 px-10 py-5 bg-ps-blue hover:bg-ps-blue/80 text-white rounded-[1.25rem] font-bold tracking-tight text-xl cursor-pointer transition-all shrink-0 transform active:scale-95">
-            <Upload className="w-7 h-7" />
-            <span>{t("storage_hub.upload_btn", "Upload ELF Payload")}</span>
+          <label className="cp-btn cp-btn--primary cp-btn--lg shrink-0 cursor-pointer inline-flex items-center justify-center gap-3">
+            <Upload className="cp-btn__icon w-6 h-6" />
+            <span className="cp-btn__label">{t("storage_hub.upload_btn", "Upload ELF Payload")}</span>
             <input type="file" className="hidden" onChange={onUpload} accept={isIOS ? undefined : ".elf,.bin"} />
           </label>
         )}
@@ -253,27 +250,29 @@ const StorageHub = ({ payloads, payloadMeta, onInstall, onDelete, onUpload, onIm
                       </div>
                     </div>
                     <div className="flex items-center shrink-0">
-                      <button
+                      <HudButton
                         onClick={() => onDelete(fileName)}
-                        className="p-3 md:p-4 rounded-xl bg-red-950/20 text-red-500 border border-red-500/10 hover:bg-red-500 hover:text-white transition-all"
+                        icon={Trash2}
+                        variant="dangerSoft"
+                        size="sm"
+                        className="cp-btn--icon"
                         title={t("storage_hub.remove_payload", "Remove Payload")}
-                      >
-                        <Trash2 className="w-5 h-5 md:w-6 md:h-6" />
-                      </button>
+                        aria-label={t("storage_hub.remove_payload", "Remove Payload")}
+                      />
                     </div>
                   </div>
                   {remoteMatch?.isUpdate && (
-                    <button
+                    <HudButton
                       onClick={() => onInstall(remoteMatch, remoteMatch.source_id, legacyRepoUrl)}
-                      className="w-full flex items-center justify-center space-x-2 py-2 bg-emerald-600 hover:bg-emerald-500 text-white rounded-xl font-bold text-xs md:text-sm transition-all"
+                      icon={RefreshCw}
+                      variant="success"
+                      size="sm"
+                      block
                     >
-                      <RefreshCw className="w-4 h-4 md:w-5 md:h-5" />
-                      <span>
-                        {remoteVersion
-                          ? t("storage_hub.update_to_version", "Update (to v{{version}})", { version: remoteVersion.replace(/^v/i, '') })
-                          : t("storage_hub.update_btn", "Update")}
-                      </span>
-                    </button>
+                      {remoteVersion
+                        ? t("storage_hub.update_to_version", "Update (to v{{version}})", { version: remoteVersion.replace(/^v/i, '') })
+                        : t("storage_hub.update_btn", "Update")}
+                    </HudButton>
                   )}
                 </div>
               )
@@ -341,7 +340,9 @@ const StorageHub = ({ payloads, payloadMeta, onInstall, onDelete, onUpload, onIm
               <p className="text-xl font-bold text-white uppercase tracking-tight">{t("storage_hub.repo_unavailable", "Repository Unavailable")}</p>
               <p className="text-zinc-500 mt-1">{t("storage_hub.repo_unavailable_desc", "Check your internet connection and try again.")}</p>
             </div>
-            <button onClick={() => fetchRemote(true)} className="px-8 py-3 bg-white/5 border border-white/10 hover:bg-white/10 text-white rounded-xl font-bold uppercase text-xs transition-all">{t("storage_hub.retry_btn", "Retry Connection")}</button>
+            <HudButton onClick={() => fetchRemote(true)} variant="secondary" size="sm">
+              {t("storage_hub.retry_btn", "Retry Connection")}
+            </HudButton>
           </div>
         ) : enrichedSources.length > 0 ? (
           /* ===== REPOSITORY CATALOGS ===== */
@@ -540,13 +541,14 @@ const StorageHub = ({ payloads, payloadMeta, onInstall, onDelete, onUpload, onIm
                     </div>
                   </div>
                   <div className="flex items-center shrink-0">
-                    <button
+                    <HudButton
                       onClick={() => onImportFromUsb(path)}
-                      className="flex items-center space-x-2 md:space-x-3 px-4 md:px-6 py-3 md:py-4 bg-white/5 hover:bg-ps-blue text-white rounded-xl font-bold text-xs md:text-sm transition-all border border-white/10 hover:border-ps-blue group/btn"
+                      icon={Database}
+                      variant="primary"
+                      size="sm"
                     >
-                      <Database className="w-4 h-4 md:w-5 md:h-5 text-ps-blue group-hover/btn:text-white transition-colors" />
-                      <span>{t("storage_hub.move_internal_btn", "Move to Internal")}</span>
-                    </button>
+                      {t("storage_hub.move_internal_btn", "Move to Internal")}
+                    </HudButton>
                   </div>
                 </div>
               )

--- a/frontend/src/components/views/StorageHub.jsx
+++ b/frontend/src/components/views/StorageHub.jsx
@@ -197,7 +197,7 @@ const StorageHub = ({ payloads, payloadMeta, onInstall, onDelete, onUpload, onIm
     <div className="space-y-12">
       <div className="flex flex-col md:flex-row md:items-center justify-between gap-8">
         <h2 className="text-4xl font-extrabold text-white tracking-tight">
-          {t("storage_hub.title_1", "Payload")} <span className="text-ps-blue">{t("storage_hub.title_2", "Management")}</span>
+          {t("storage_hub.title_1", "Payload")} <span className="cp-title-accent">{t("storage_hub.title_2", "Management")}</span>
         </h2>
 
         {!isPS5 && (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,24 +1,32 @@
+/* Theme packages must come first (CSS @import rule order) */
+@import './theme/theme-shared.css';
+@import './theme/theme-classic.css';
+@import './theme/theme-cyberpunk.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-/** 
+/**
  * LEGACY FALLBACKS
- * These ensure basic functionality on PS5 firmware < 5.0 (Safari < 15.4)
- * which does not support CSS Cascading Layers (@layer).
+ * Basic utilities for PS5 firmware < 5.0 (Safari < 15.4) without CSS layers.
  */
 .hidden { display: none !important; }
 .flex { display: flex !important; }
-/* NOTE: flex-col must NOT have !important so md:flex-row can override it */
 .flex-col { flex-direction: column; }
 .items-center { align-items: center !important; }
 .justify-center { justify-content: center !important; }
+.min-h-0 { min-height: 0 !important; }
+.flex-1 { flex: 1 1 0% !important; }
+.overflow-hidden { overflow: hidden !important; }
+.overflow-y-auto { overflow-y: auto !important; }
 .ps5-bg { background-color: var(--color-ps-black) !important; }
 .text-white { color: #ffffff !important; }
 .text-zinc-100 { color: #f4f4f5 !important; }
 .text-zinc-300 { color: #d4d4d8 !important; }
 .text-zinc-400 { color: #a1a1aa !important; }
-.text-ps-blue { color: #0095ff !important; }
+.text-ps-blue { color: var(--color-ps-blue) !important; }
+
 @media (min-width: 768px) {
   .md\:hidden { display: none !important; }
   .md\:flex { display: flex !important; }
@@ -39,16 +47,13 @@
   .md\:space-y-6 > * + * { margin-top: 1.5rem !important; }
   .md\:space-y-8 > * + * { margin-top: 2rem !important; }
   .md\:space-y-12 > * + * { margin-top: 3rem !important; }
-  
   .md\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)) !important; }
   .md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)) !important; }
   .md\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)) !important; }
-  
   .md\:gap-4 { gap: 1rem !important; }
   .md\:gap-6 { gap: 1.5rem !important; }
   .md\:gap-8 { gap: 2rem !important; }
   .md\:gap-12 { gap: 3rem !important; }
-  
   .md\:p-6 { padding: 1.5rem !important; }
   .md\:p-8 { padding: 2rem !important; }
   .md\:p-12 { padding: 3rem !important; }
@@ -65,179 +70,3 @@
   .lg\:block { display: block !important; }
   .lg\:hidden { display: none !important; }
 }
-
-:root {
-  --color-ps-blue: #0095ff;
-  --color-ps-blue-glow: rgba(0, 149, 255, 0.4);
-  --color-ps-black: #08080a;
-  --color-ps-surface: #101014;
-  --color-ps-card: rgba(24, 24, 28, 0.8);
-  --color-ps-border: rgba(255, 255, 255, 0.08);
-  
-  --font-inter: "Inter", system-ui, sans-serif;
-  
-  --radius-ps-xl: 1rem;
-  --radius-ps-2xl: 1.5rem;
-  --radius-ps-3xl: 2rem;
-}
-
-/* @theme removed - Tailwind 4 only directive, using tailwind.config.js instead */
-
-:root {
-  color-scheme: dark;
-}
-
-html, body {
-  height: 100%;
-  height: -webkit-fill-available;
-}
-
-body {
-  margin: 0;
-  padding: 0;
-  background-color: var(--color-ps-black);
-  color: #f4f4f5;
-  font-family: var(--font-inter);
-  font-size: 16px; /* Default for mobile/web */
-  -webkit-font-smoothing: antialiased;
-  overflow-x: hidden;
-  padding-bottom: env(safe-area-inset-bottom);
-}
-
-@media (min-width: 768px) {
-  body {
-    overflow: hidden;
-    height: 100vh;
-    font-size: 20px; /* Larger for TV/Large Screens */
-  }
-}
-
-.ps5-bg {
-  background-color: var(--color-ps-black);
-  /* background-image: 
-    radial-gradient(circle at 0% 0%, rgba(0, 149, 255, 0.05) 0%, transparent 50%),
-    radial-gradient(circle at 100% 100%, rgba(0, 149, 255, 0.03) 0%, transparent 50%); */
-}
-
-/* Custom Scrollbar */
-::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
-}
-
-::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-::-webkit-scrollbar-thumb {
-  background: #444;
-  border-radius: 10px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-  background: var(--color-ps-blue);
-}
-
-/* Glassmorphism & Cards */
-.glass-panel {
-  background: var(--color-ps-surface);
-  border-right: 1px solid var(--color-ps-border);
-/* backdrop-filter: blur(12px); */
-}
-
-.glass-card {
-  background: var(--color-ps-card);
-  border: 1px solid var(--color-ps-border);
-  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
-/* box-shadow: 0 4px 20px -2px rgba(0, 0, 0, 0.5); */
-}
-
-.glass-card:hover, .glass-card:focus {
-  background: rgba(40, 40, 45, 0.95);
-  border-color: var(--color-ps-blue);
-  transform: translateY(-2px);
-/* box-shadow: 0 0 30px var(--color-ps-blue-glow); */
-  outline: none;
-}
-
-/* Sidebar Item Focus */
-button:focus {
-  outline: none;
-}
-
-/* Neon Glows */
-.neon-text {
-/* text-shadow: 0 0 10px var(--color-ps-blue-glow); */
-}
-
-.neon-border {
-/* box-shadow: 0 0 15px var(--color-ps-blue-glow); */
-}
-
-/* Typography */
-h1, h2, h3, h4 {
-  font-weight: 800;
-  letter-spacing: -0.025em;
-}
-
-.label-caps {
-  text-transform: uppercase;
-  font-weight: 700;
-  letter-spacing: 0.1em;
-  font-size: 0.85rem;
-  color: #a1a1aa; /* Increased contrast from #71717a */
-}
-
-/* Animations */
-@keyframes fadeIn {
-  from { opacity: 0; transform: translateY(10px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-@keyframes spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-}
-
-@-webkit-keyframes spin {
-  from { -webkit-transform: rotate(0deg); }
-  to { -webkit-transform: rotate(360deg); }
-}
-
-.animate-fade-in {
-  /* animation: fadeIn 0.4s ease-out forwards; */
-}
-
-.animate-spin {
-  /* animation: spin 1s linear infinite;
-  -webkit-animation: spin 1s linear infinite; */
-  transform-origin: center;
-  -webkit-transform-origin: center;
-  will-change: transform;
-}
-
-/* Robust PS5 Spinner - Using unique keyframe name and solid borders */
-.ps5-robust-spinner {
-  width: 6rem;
-  height: 6rem;
-  border: 8px solid rgba(255, 255, 255, 0.05);
-  border-left-color: var(--color-ps-blue);
-  border-radius: 50%;
-  animation: ps5-native-spin 1s linear infinite;
-  -webkit-animation: ps5-native-spin 1s linear infinite;
-  will-change: transform;
-}
-
-@keyframes ps5-native-spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
-}
-
-@-webkit-keyframes ps5-native-spin {
-  from { -webkit-transform: rotate(0deg); }
-  to { -webkit-transform: rotate(360deg); }
-}
-
-.hide-scrollbar::-webkit-scrollbar { display: none; }
-.hide-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
-

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,11 +2,23 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
-import './i18n';
+import './i18n'
+import { ThemeProvider } from './theme/ThemeContext.jsx'
+import { applyThemeVars, DEFAULT_THEME, THEME_STORAGE_KEY, THEMES } from './theme/themes.js'
+
+// Apply theme before first paint to avoid flash
+try {
+  const saved = localStorage.getItem(THEME_STORAGE_KEY)
+  applyThemeVars(saved && THEMES[saved] ? saved : DEFAULT_THEME)
+} catch (_) {
+  applyThemeVars(DEFAULT_THEME)
+}
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </StrictMode>,
 )
 
@@ -18,6 +30,3 @@ if (window.applicationCache) {
     }
   }, false);
 }
-
-
-

--- a/frontend/src/theme/README.md
+++ b/frontend/src/theme/README.md
@@ -1,0 +1,117 @@
+# Themes
+
+Payload Manager themes are **packs**: tokens + feature flags + a CSS chrome family (`skin`).
+
+## Concepts
+
+| Layer | What it is | How it is selected |
+|-------|------------|--------------------|
+| **Pack id** (`data-theme`) | Identity / storage key | `defineTheme('matrix', …)` |
+| **Skin** (`data-skin`) | CSS chrome family | `skin: 'cyberpunk'` or inherited via `extends` |
+| **Features** | Optional DOM / UX modules | `features: { atmosphere: true, … }` + `hasFeature()` |
+| **Vars** | CSS custom properties | full set or overrides on top of `extends` |
+
+Built-in skins:
+
+- `classic` → `theme-classic.css`
+- `cyberpunk` → `theme-cyberpunk.css`
+
+A palette-only theme can `extends: 'cyberpunk'` and get the HUD chrome **without** copying CSS or touching JSX.
+
+## Add a theme in 4 steps
+
+### 1. Register the pack (`themes.js`)
+
+```js
+defineTheme('matrix', {
+  label: 'Matrix',
+  description: 'HUD chrome with green phosphor palette',
+  // Reuse cyberpunk chrome modules + CSS skin:
+  extends: 'cyberpunk',
+  swatches: ['#00ff66', '#003311', '#0a0f0a', '#001a0a'],
+  favicon: '/favicon-cyberpunk.svg', // or public/favicon-matrix.svg
+  // Only override what changes:
+  vars: {
+    '--color-ps-blue': '#00ff66',
+    '--color-ps-blue-glow': 'rgba(0, 255, 102, 0.45)',
+    '--color-ps-red': '#00cc55',
+    '--color-title-accent': '#00ff66',
+    '--color-nav-idle': 'rgba(0, 255, 100, 0.55)',
+    '--color-nav-active': '#00ff66',
+    '--color-brand': '#00ff66',
+    '--color-brand-icon-fg': '#00ff66',
+  },
+})
+```
+
+`extends` merges **vars**, **features**, and **skin** from the base theme, then applies your overrides.
+
+### 2. Feature flags (chrome modules)
+
+| Feature | What it enables |
+|---------|-----------------|
+| `atmosphere` | Code-rain / haze backdrop |
+| `hudBar` | Top HUD strip (version / IP) |
+| `hazardStripe` | Yellow hazard tape |
+| `flatlinedError` | FLATLINED death screen (else classic error cards) |
+| `hudControls` | Segmented OFF\|ON toggles + bar-style buttons |
+| `densePadding` | Tighter main content padding |
+
+In components:
+
+```js
+const { hasFeature } = useTheme()
+// or: import { useThemeFeature } from '../theme/ThemeContext'
+if (hasFeature('atmosphere')) return <Atmosphere />
+```
+
+**Do not** use `themeId === 'cyberpunk'` for behavior — that blocks new themes.
+
+### 3. Optional CSS overrides
+
+Create `theme-matrix.css` only if tokens + the inherited skin cannot express something:
+
+```css
+[data-theme="matrix"] .some-special-shape {
+  /* pack-specific one-offs */
+}
+
+/* Or a brand-new chrome family: */
+[data-skin="matrix"] .cp-btn { /* … */ }
+```
+
+Import new stylesheets from `src/index.css` after the shared theme CSS.
+
+Also available on `<html>`:
+
+```html
+data-theme="matrix"
+data-skin="cyberpunk"
+data-feature-atmosphere="1"
+data-feature-hudBar="1"
+…
+```
+
+### 4. Favicon (optional)
+
+Add `public/favicon-<id>.svg` and set `favicon: '/favicon-<id>.svg'` on the pack.
+`applyThemeVars` swaps the tab icon automatically.
+
+## Token checklist
+
+Every fully resolved theme must define all keys in `THEME_VAR_KEYS` (via base + overrides).
+Missing keys log a console warning.
+
+## Settings UI
+
+The Appearance grid auto-lists `Object.values(THEMES)`.  
+Use `swatches: ['#…', …]` for the color chips (up to 4 shown). Falls back to key brand tokens if omitted.
+
+## Built-in packs
+
+| id | skin | Role |
+|----|------|------|
+| `classic` | `classic` | Default — clean PS blue UI, simple errors |
+| `cyberpunk` | `cyberpunk` | Full HUD chrome + FLATLINED |
+
+`DEFAULT_THEME` is `classic`.

--- a/frontend/src/theme/ThemeContext.jsx
+++ b/frontend/src/theme/ThemeContext.jsx
@@ -1,17 +1,21 @@
-import React, { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react'
 import {
   DEFAULT_THEME,
   THEME_STORAGE_KEY,
   THEMES,
   applyThemeVars,
   getTheme,
+  listThemes,
+  themeHasFeature,
 } from './themes'
 
 const ThemeContext = createContext({
   themeId: DEFAULT_THEME,
   theme: getTheme(DEFAULT_THEME),
+  features: getTheme(DEFAULT_THEME).features,
   setThemeId: () => {},
   themes: THEMES,
+  hasFeature: () => false,
 })
 
 export function ThemeProvider({ children }) {
@@ -30,14 +34,24 @@ export function ThemeProvider({ children }) {
     } catch (_) { /* ignore */ }
   }, [themeId])
 
+  const theme = useMemo(() => getTheme(themeId), [themeId])
+
+  const hasFeature = useCallback(
+    (feature) => themeHasFeature(themeId, feature),
+    [themeId]
+  )
+
   const value = useMemo(
     () => ({
       themeId,
-      theme: getTheme(themeId),
+      theme,
+      features: theme.features,
       setThemeId: setThemeIdState,
       themes: THEMES,
+      listThemes,
+      hasFeature,
     }),
-    [themeId]
+    [themeId, theme, hasFeature]
   )
 
   return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
@@ -45,4 +59,10 @@ export function ThemeProvider({ children }) {
 
 export function useTheme() {
   return useContext(ThemeContext)
+}
+
+/** Convenience: feature flag for the active theme */
+export function useThemeFeature(feature) {
+  const { hasFeature } = useTheme()
+  return hasFeature(feature)
 }

--- a/frontend/src/theme/ThemeContext.jsx
+++ b/frontend/src/theme/ThemeContext.jsx
@@ -1,0 +1,48 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react'
+import {
+  DEFAULT_THEME,
+  THEME_STORAGE_KEY,
+  THEMES,
+  applyThemeVars,
+  getTheme,
+} from './themes'
+
+const ThemeContext = createContext({
+  themeId: DEFAULT_THEME,
+  theme: getTheme(DEFAULT_THEME),
+  setThemeId: () => {},
+  themes: THEMES,
+})
+
+export function ThemeProvider({ children }) {
+  const [themeId, setThemeIdState] = useState(() => {
+    try {
+      const saved = localStorage.getItem(THEME_STORAGE_KEY)
+      if (saved && THEMES[saved]) return saved
+    } catch (_) { /* ignore */ }
+    return DEFAULT_THEME
+  })
+
+  useEffect(() => {
+    applyThemeVars(themeId)
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, themeId)
+    } catch (_) { /* ignore */ }
+  }, [themeId])
+
+  const value = useMemo(
+    () => ({
+      themeId,
+      theme: getTheme(themeId),
+      setThemeId: setThemeIdState,
+      themes: THEMES,
+    }),
+    [themeId]
+  )
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>
+}
+
+export function useTheme() {
+  return useContext(ThemeContext)
+}

--- a/frontend/src/theme/theme-classic.css
+++ b/frontend/src/theme/theme-classic.css
@@ -108,13 +108,15 @@
   box-shadow: 0 0 20px rgba(220, 38, 38, 0.3) !important;
 }
 
-/* Classic brand toggle shouldn't flash yellow (cyber accent) */
-[data-theme="classic"] .cp-sidebar__brand button {
+/* Classic hamburger — PS blue hover */
+[data-theme="classic"] .cp-sidebar__toggle {
   border-radius: 0.75rem !important;
   border: none !important;
+  color: #a1a1aa;
 }
 
-[data-theme="classic"] .cp-sidebar__brand button:hover {
+[data-theme="classic"] .cp-sidebar__toggle:hover,
+[data-theme="classic"] .cp-sidebar__toggle:focus-visible {
   background: #0095ff !important;
   color: #ffffff !important;
 }
@@ -313,4 +315,15 @@
 
 [data-theme="classic"] .cp-log-line__prompt {
   color: rgba(0, 149, 255, 0.85);
+}
+
+[data-theme="classic"] .cp-autoload-off__panel {
+  border-radius: 1.5rem !important;
+}
+
+[data-theme="classic"] .cp-autoload-off__icon {
+  border-radius: 1.25rem !important;
+  color: #0095ff;
+  background: rgba(0, 149, 255, 0.1);
+  border-color: rgba(0, 149, 255, 0.25);
 }

--- a/frontend/src/theme/theme-classic.css
+++ b/frontend/src/theme/theme-classic.css
@@ -1,0 +1,118 @@
+/**
+ * CLASSIC theme only — original PS blue manager.
+ * Nothing cyberpunk lives here. Scope: [data-theme="classic"]
+ */
+
+[data-theme="classic"] .ps5-bg {
+  background-image: none !important;
+  background-color: var(--color-ps-black) !important;
+}
+
+[data-theme="classic"] .ps5-bg::before {
+  content: none !important;
+  display: none !important;
+}
+
+[data-theme="classic"] .cp-sidebar {
+  background: rgba(0, 0, 0, 0.4) !important;
+  border-right: 1px solid rgba(255, 255, 255, 0.05) !important;
+  box-shadow: none !important;
+}
+
+[data-theme="classic"] .cp-brand {
+  letter-spacing: -0.02em !important;
+  text-transform: none !important;
+  color: #fff !important;
+  text-shadow: none !important;
+}
+
+[data-theme="classic"] .cp-brand-icon {
+  background: var(--color-ps-blue) !important;
+  color: #fff !important;
+  border: none !important;
+  box-shadow: none !important;
+  border-radius: 0.75rem !important;
+}
+
+[data-theme="classic"] .cp-nav-item {
+  letter-spacing: 0.04em !important;
+  border-radius: 1rem !important;
+  text-shadow: none !important;
+}
+
+[data-theme="classic"] .cp-nav-item.is-active {
+  color: #fff !important;
+  background: var(--color-ps-blue) !important;
+  border-color: transparent !important;
+  box-shadow: 0 0 20px var(--color-ps-blue-glow) !important;
+  text-shadow: none !important;
+}
+
+[data-theme="classic"] .cp-nav-item:hover:not(.is-active) {
+  color: #fff !important;
+  background: rgba(255, 255, 255, 0.05) !important;
+}
+
+[data-theme="classic"] .glass-card {
+  box-shadow: none !important;
+  border-color: rgba(255, 255, 255, 0.08) !important;
+}
+
+[data-theme="classic"] .glass-card:hover,
+[data-theme="classic"] .glass-card:focus {
+  background: rgba(40, 40, 45, 0.95) !important;
+  border-color: var(--color-ps-blue) !important;
+  box-shadow: none !important;
+}
+
+[data-theme="classic"] .cp-progress-fill {
+  background: var(--color-ps-blue) !important;
+  box-shadow: none !important;
+}
+
+[data-theme="classic"] .cp-title-accent {
+  text-shadow: none !important;
+}
+
+[data-theme="classic"] h1,
+[data-theme="classic"] h2,
+[data-theme="classic"] h3,
+[data-theme="classic"] h4 {
+  letter-spacing: -0.025em !important;
+  text-transform: none !important;
+}
+
+[data-theme="classic"] .label-caps {
+  color: #a1a1aa !important;
+  letter-spacing: 0.1em !important;
+}
+
+[data-theme="classic"] .ps5-robust-spinner {
+  border: 8px solid rgba(255, 255, 255, 0.05) !important;
+  border-left-color: var(--color-ps-blue) !important;
+  border-top-color: transparent !important;
+  box-shadow: none !important;
+}
+
+[data-theme="classic"] ::-webkit-scrollbar-thumb,
+[data-theme="classic"] .custom-scrollbar::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.15) !important;
+  border-radius: 10px !important;
+}
+
+/* Classic never shows cyberpunk chrome (even if left in DOM) */
+[data-theme="classic"] .cp-atm,
+[data-theme="classic"] .cp-hudbar {
+  display: none !important;
+  visibility: hidden !important;
+  pointer-events: none !important;
+  height: 0 !important;
+  min-height: 0 !important;
+  overflow: hidden !important;
+  opacity: 0 !important;
+}
+
+[data-theme="classic"] nav.fixed.bottom-0 {
+  border-top-color: rgba(255, 255, 255, 0.08) !important;
+  background: rgba(8, 8, 10, 0.95) !important;
+}

--- a/frontend/src/theme/theme-classic.css
+++ b/frontend/src/theme/theme-classic.css
@@ -328,23 +328,139 @@
   border-color: rgba(0, 149, 255, 0.25);
 }
 
-[data-theme="classic"] .cp-flatlined {
-  background: #08080a;
+/* Classic error screen — clean card, no death-menu chrome */
+[data-theme="classic"] .cp-flatlined,
+[data-theme="classic"] .cp-flatlined--classic {
+  background: transparent;
+  justify-content: center;
+  padding: 1.5rem 1rem;
+}
+
+[data-theme="classic"] .cp-flatlined--embedded {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 1.25rem;
+  background: rgba(255, 255, 255, 0.02);
+  min-height: 20rem;
 }
 
 [data-theme="classic"] .cp-flatlined__panel {
-  border-radius: 1rem;
-  border-color: rgba(255, 255, 255, 0.1);
-  background: rgba(16, 16, 20, 0.9);
+  margin-left: 0;
+  max-width: 28rem;
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(16, 16, 20, 0.95);
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
+  padding: 2rem 1.75rem 1.75rem;
 }
 
-[data-theme="classic"] .cp-flatlined__title {
-  color: #ef4444;
-  text-shadow: none;
-  letter-spacing: -0.02em;
+[data-theme="classic"] .cp-flatlined__brand {
+  gap: 1rem;
+  margin-bottom: 1.25rem;
+  align-items: flex-start;
+}
+
+[data-theme="classic"] .cp-flatlined__icon-wrap {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 3.25rem;
+  height: 3.25rem;
+  border-radius: 1rem;
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  flex-shrink: 0;
 }
 
 [data-theme="classic"] .cp-flatlined__skull {
-  color: #ef4444;
+  width: 1.75rem;
+  height: 1.75rem;
+  color: #f87171;
   filter: none;
+}
+
+[data-theme="classic"] .cp-flatlined__title {
+  font-size: 1.35rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  text-transform: none;
+  color: #f4f4f5;
+  text-shadow: none;
+  line-height: 1.25;
+}
+
+[data-theme="classic"] .cp-flatlined__deck {
+  margin-top: 0.35rem;
+  font-size: 0.7rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #a1a1aa;
+}
+
+[data-theme="classic"] .cp-flatlined__msg {
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #fafafa;
+  margin-bottom: 0.5rem;
+}
+
+[data-theme="classic"] .cp-flatlined__detail {
+  color: #a1a1aa;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  margin-bottom: 1.5rem;
+}
+
+[data-theme="classic"] .cp-flatlined__detail strong {
+  color: #0095ff;
+  font-weight: 700;
+}
+
+[data-theme="classic"] .cp-flatlined__classic-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.6rem;
+  width: 100%;
+  padding: 0.95rem 1.25rem;
+  border: none;
+  border-radius: 0.9rem;
+  background: #0095ff;
+  color: #fff;
+  font-family: inherit;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.1s ease;
+}
+
+[data-theme="classic"] .cp-flatlined__classic-btn:hover {
+  background: #33aaff;
+}
+
+[data-theme="classic"] .cp-flatlined__classic-btn:active {
+  transform: scale(0.98);
+}
+
+[data-theme="classic"] .cp-flatlined__menu-item {
+  text-align: center;
+  letter-spacing: 0.04em;
+  text-transform: none;
+  font-weight: 600;
+  color: #71717a;
+  border-radius: 0.75rem;
+}
+
+[data-theme="classic"] .cp-flatlined__menu-item:hover {
+  color: #0095ff;
+  border-color: rgba(0, 149, 255, 0.35);
+  background: rgba(0, 149, 255, 0.06);
+}
+
+/* Hide any residual cyber chrome if class leaks */
+[data-theme="classic"] .cp-flatlined__rain,
+[data-theme="classic"] .cp-flatlined__scan,
+[data-theme="classic"] .cp-flatlined__vignette,
+[data-theme="classic"] .cp-flatlined__top,
+[data-theme="classic"] .cp-flatlined__foot {
+  display: none !important;
 }

--- a/frontend/src/theme/theme-classic.css
+++ b/frontend/src/theme/theme-classic.css
@@ -1,27 +1,27 @@
 /**
  * CLASSIC theme only — original PS blue manager.
- * Nothing cyberpunk lives here. Scope: [data-theme="classic"]
+ * Nothing cyberpunk lives here. Scope: [data-skin="classic"]
  */
 
-[data-theme="classic"] .ps5-bg {
+[data-skin="classic"] .ps5-bg {
   background-image: none !important;
   background-color: var(--color-ps-black) !important;
 }
 
-[data-theme="classic"] .ps5-bg::before {
+[data-skin="classic"] .ps5-bg::before {
   content: none !important;
   display: none !important;
 }
 
-[data-theme="classic"] .cp-sidebar {
+[data-skin="classic"] .cp-sidebar {
   background: rgba(0, 0, 0, 0.4) !important;
   border-right: 1px solid rgba(255, 255, 255, 0.05) !important;
   box-shadow: none !important;
 }
 
 /* Classic collapsed: circular-ish icon pills that fit the rail */
-[data-theme="classic"] .cp-sidebar--collapsed .cp-nav-item,
-[data-theme="classic"] .cp-sidebar .cp-nav-item.justify-center {
+[data-skin="classic"] .cp-sidebar--collapsed .cp-nav-item,
+[data-skin="classic"] .cp-sidebar .cp-nav-item.justify-center {
   justify-content: center !important;
   width: 2.75rem !important;
   min-width: 2.75rem !important;
@@ -33,11 +33,11 @@
   gap: 0 !important;
 }
 
-[data-theme="classic"] .cp-sidebar--collapsed .cp-nav-item > span {
+[data-skin="classic"] .cp-sidebar--collapsed .cp-nav-item > span {
   display: none !important;
 }
 
-[data-theme="classic"] .cp-sidebar--collapsed .cp-sidebar__toggle {
+[data-skin="classic"] .cp-sidebar--collapsed .cp-sidebar__toggle {
   width: 2.75rem;
   height: 2.75rem;
   padding: 0;
@@ -46,14 +46,14 @@
   justify-content: center;
 }
 
-[data-theme="classic"] .cp-brand {
+[data-skin="classic"] .cp-brand {
   letter-spacing: -0.02em !important;
   text-transform: none !important;
   color: #fff !important;
   text-shadow: none !important;
 }
 
-[data-theme="classic"] .cp-brand-icon {
+[data-skin="classic"] .cp-brand-icon {
   background: var(--color-ps-blue) !important;
   color: #fff !important;
   border: none !important;
@@ -62,7 +62,7 @@
 }
 
 /* Classic sidebar — original PS blue pill buttons */
-[data-theme="classic"] .cp-sidebar .cp-nav-item {
+[data-skin="classic"] .cp-sidebar .cp-nav-item {
   letter-spacing: -0.01em !important;
   border-radius: 1rem !important;
   border: none !important;
@@ -75,12 +75,12 @@
   font-family: system-ui, "Segoe UI", sans-serif !important;
 }
 
-[data-theme="classic"] .cp-sidebar .cp-nav-item:not(.is-active) {
+[data-skin="classic"] .cp-sidebar .cp-nav-item:not(.is-active) {
   color: #a1a1aa !important;
   background: transparent !important;
 }
 
-[data-theme="classic"] .cp-sidebar .cp-nav-item.is-active {
+[data-skin="classic"] .cp-sidebar .cp-nav-item.is-active {
   color: #ffffff !important;
   background: #0095ff !important;
   border-color: transparent !important;
@@ -88,82 +88,82 @@
   text-shadow: none !important;
 }
 
-[data-theme="classic"] .cp-sidebar .cp-nav-item.is-active svg {
+[data-skin="classic"] .cp-sidebar .cp-nav-item.is-active svg {
   color: #ffffff !important;
   filter: none !important;
 }
 
-[data-theme="classic"] .cp-sidebar .cp-nav-item:hover:not(.is-active) {
+[data-skin="classic"] .cp-sidebar .cp-nav-item:hover:not(.is-active) {
   color: #ffffff !important;
   background: rgba(255, 255, 255, 0.05) !important;
 }
 
-[data-theme="classic"] .cp-sidebar .cp-nav-item.cp-nav-donate:not(.is-active) {
+[data-skin="classic"] .cp-sidebar .cp-nav-item.cp-nav-donate:not(.is-active) {
   color: rgba(239, 68, 68, 0.7) !important;
 }
 
-[data-theme="classic"] .cp-sidebar .cp-nav-item.cp-nav-donate.is-active {
+[data-skin="classic"] .cp-sidebar .cp-nav-item.cp-nav-donate.is-active {
   color: #ffffff !important;
   background: #dc2626 !important;
   box-shadow: 0 0 20px rgba(220, 38, 38, 0.3) !important;
 }
 
 /* Classic hamburger — PS blue hover */
-[data-theme="classic"] .cp-sidebar__toggle {
+[data-skin="classic"] .cp-sidebar__toggle {
   border-radius: 0.75rem !important;
   border: none !important;
   color: #a1a1aa;
 }
 
-[data-theme="classic"] .cp-sidebar__toggle:hover,
-[data-theme="classic"] .cp-sidebar__toggle:focus-visible {
+[data-skin="classic"] .cp-sidebar__toggle:hover,
+[data-skin="classic"] .cp-sidebar__toggle:focus-visible {
   background: #0095ff !important;
   color: #ffffff !important;
 }
 
-[data-theme="classic"] .glass-card {
+[data-skin="classic"] .glass-card {
   box-shadow: none !important;
   border-color: rgba(255, 255, 255, 0.08) !important;
 }
 
-[data-theme="classic"] .glass-card:hover,
-[data-theme="classic"] .glass-card:focus {
+[data-skin="classic"] .glass-card:hover,
+[data-skin="classic"] .glass-card:focus {
   background: rgba(40, 40, 45, 0.95) !important;
   border-color: var(--color-ps-blue) !important;
   box-shadow: none !important;
 }
 
-[data-theme="classic"] .cp-progress-fill {
+[data-skin="classic"] .cp-progress-fill {
   background: var(--color-ps-blue) !important;
   box-shadow: none !important;
 }
 
-[data-theme="classic"] .cp-title-accent {
+[data-skin="classic"] .cp-title-accent {
   text-shadow: none !important;
 }
 
-[data-theme="classic"] h1,
-[data-theme="classic"] h2,
-[data-theme="classic"] h3,
-[data-theme="classic"] h4 {
+[data-skin="classic"] h1,
+[data-skin="classic"] h2,
+[data-skin="classic"] h3,
+[data-skin="classic"] h4 {
   letter-spacing: -0.025em !important;
   text-transform: none !important;
 }
 
-[data-theme="classic"] .label-caps {
+[data-skin="classic"] .label-caps {
   color: #a1a1aa !important;
   letter-spacing: 0.1em !important;
 }
 
-[data-theme="classic"] .ps5-robust-spinner {
+[data-skin="classic"] .ps5-robust-spinner {
   border: 8px solid rgba(255, 255, 255, 0.05) !important;
   border-left-color: var(--color-ps-blue) !important;
   border-top-color: transparent !important;
   box-shadow: none !important;
 }
 
-[data-theme="classic"] ::-webkit-scrollbar-thumb,
-[data-theme="classic"] .custom-scrollbar::-webkit-scrollbar-thumb {
+[data-skin="classic"] ::-webkit-scrollbar-thumb,
+[data-skin="classic"] .custom-scrollbar::-webkit-scrollbar-thumb {
   background: rgba(255, 255, 255, 0.15) !important;
   border-radius: 10px !important;
 }
@@ -172,7 +172,7 @@
  * Classic .cp-btn fallbacks — when markup uses HudButton classes (e.g. <label>),
  * still render as original rounded PS blue pills.
  */
-[data-theme="classic"] .cp-btn {
+[data-skin="classic"] .cp-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -190,40 +190,40 @@
   transition: background 0.15s ease, transform 0.1s ease;
 }
 
-[data-theme="classic"] .cp-btn:hover {
+[data-skin="classic"] .cp-btn:hover {
   background: rgba(0, 149, 255, 0.85);
 }
 
-[data-theme="classic"] .cp-btn--lg {
+[data-skin="classic"] .cp-btn--lg {
   padding: 1.15rem 2.25rem;
   font-size: 1.15rem;
   border-radius: 1.25rem;
 }
 
-[data-theme="classic"] .cp-btn--sm {
+[data-skin="classic"] .cp-btn--sm {
   padding: 0.5rem 1rem;
   font-size: 0.875rem;
   border-radius: 0.75rem;
 }
 
-[data-theme="classic"] .cp-btn--primary {
+[data-skin="classic"] .cp-btn--primary {
   background: #0095ff;
   color: #fff;
 }
 
-[data-theme="classic"] .cp-btn--secondary,
-[data-theme="classic"] .cp-btn--ghost {
+[data-skin="classic"] .cp-btn--secondary,
+[data-skin="classic"] .cp-btn--ghost {
   background: rgba(255, 255, 255, 0.05);
   color: #fff;
   border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
-[data-theme="classic"] .cp-btn--danger {
+[data-skin="classic"] .cp-btn--danger {
   background: #dc2626;
   color: #fff;
 }
 
-[data-theme="classic"] .cp-btn--dangerSoft {
+[data-skin="classic"] .cp-btn--dangerSoft {
   background: rgba(239, 68, 68, 0.1);
   color: #ef4444;
   border: 1px solid rgba(239, 68, 68, 0.1);
@@ -231,42 +231,42 @@
   border-radius: 0.75rem;
 }
 
-[data-theme="classic"] .cp-btn--success {
+[data-skin="classic"] .cp-btn--success {
   background: #059669;
   color: #fff;
 }
 
-[data-theme="classic"] .cp-btn--block,
-[data-theme="classic"] .cp-btn--bar {
+[data-skin="classic"] .cp-btn--block,
+[data-skin="classic"] .cp-btn--bar {
   width: 100%;
 }
 
-[data-theme="classic"] .cp-btn__label {
+[data-skin="classic"] .cp-btn__label {
   font-weight: inherit;
 }
 
 /* Classic settings cards — soft blue hover (match original) */
-[data-theme="classic"] .setting-row {
+[data-skin="classic"] .setting-row {
   border-radius: 1.5rem !important;
 }
 
-[data-theme="classic"] .setting-row:hover {
+[data-skin="classic"] .setting-row:hover {
   border-color: rgba(0, 149, 255, 0.3) !important;
 }
 
-[data-theme="classic"] .setting-row:hover .setting-row__icon {
+[data-skin="classic"] .setting-row:hover .setting-row__icon {
   background: rgba(0, 149, 255, 0.1) !important;
   color: #0095ff !important;
 }
 
-[data-theme="classic"] .setting-row__title {
+[data-skin="classic"] .setting-row__title {
   letter-spacing: -0.01em !important;
   font-family: system-ui, "Segoe UI", sans-serif !important;
 }
 
 /* Classic never shows cyberpunk chrome (even if left in DOM) */
-[data-theme="classic"] .cp-atm,
-[data-theme="classic"] .cp-hudbar {
+[data-skin="classic"] .cp-atm,
+[data-skin="classic"] .cp-hudbar {
   display: none !important;
   visibility: hidden !important;
   pointer-events: none !important;
@@ -276,52 +276,52 @@
   opacity: 0 !important;
 }
 
-[data-theme="classic"] nav.fixed.bottom-0 {
+[data-skin="classic"] nav.fixed.bottom-0 {
   border-top-color: rgba(255, 255, 255, 0.08) !important;
   background: rgba(8, 8, 10, 0.95) !important;
 }
 
-[data-theme="classic"] .cp-delay-card {
+[data-skin="classic"] .cp-delay-card {
   border-radius: 1.5rem !important;
 }
 
-[data-theme="classic"] .cp-btn.is-selected,
-[data-theme="classic"] .cp-btn--selected {
+[data-skin="classic"] .cp-btn.is-selected,
+[data-skin="classic"] .cp-btn--selected {
   background: #0095ff !important;
   color: #fff !important;
   border-color: #0095ff !important;
   transform: scale(1.02);
 }
 
-[data-theme="classic"] .cp-log-overlay {
+[data-skin="classic"] .cp-log-overlay {
   background: #08080a;
 }
 
-[data-theme="classic"] .cp-log-overlay__header {
+[data-skin="classic"] .cp-log-overlay__header {
   border-bottom-color: rgba(255, 255, 255, 0.08);
   background: rgba(8, 8, 10, 0.96);
 }
 
-[data-theme="classic"] .cp-log-overlay__title h3 {
+[data-skin="classic"] .cp-log-overlay__title h3 {
   font-style: italic;
   letter-spacing: -0.03em;
   color: #fff;
   text-shadow: none;
 }
 
-[data-theme="classic"] .cp-log-line:hover {
+[data-skin="classic"] .cp-log-line:hover {
   border-left-color: #0095ff;
 }
 
-[data-theme="classic"] .cp-log-line__prompt {
+[data-skin="classic"] .cp-log-line__prompt {
   color: rgba(0, 149, 255, 0.85);
 }
 
-[data-theme="classic"] .cp-autoload-off__panel {
+[data-skin="classic"] .cp-autoload-off__panel {
   border-radius: 1.5rem !important;
 }
 
-[data-theme="classic"] .cp-autoload-off__icon {
+[data-skin="classic"] .cp-autoload-off__icon {
   border-radius: 1.25rem !important;
   color: #0095ff;
   background: rgba(0, 149, 255, 0.1);
@@ -329,21 +329,21 @@
 }
 
 /* Classic error screen — clean card, no death-menu chrome */
-[data-theme="classic"] .cp-flatlined,
-[data-theme="classic"] .cp-flatlined--classic {
+[data-skin="classic"] .cp-flatlined,
+[data-skin="classic"] .cp-flatlined--classic {
   background: transparent;
   justify-content: center;
   padding: 1.5rem 1rem;
 }
 
-[data-theme="classic"] .cp-flatlined--embedded {
+[data-skin="classic"] .cp-flatlined--embedded {
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 1.25rem;
   background: rgba(255, 255, 255, 0.02);
   min-height: 20rem;
 }
 
-[data-theme="classic"] .cp-flatlined__panel {
+[data-skin="classic"] .cp-flatlined__panel {
   margin-left: 0;
   max-width: 28rem;
   border-radius: 1.5rem;
@@ -353,13 +353,13 @@
   padding: 2rem 1.75rem 1.75rem;
 }
 
-[data-theme="classic"] .cp-flatlined__brand {
+[data-skin="classic"] .cp-flatlined__brand {
   gap: 1rem;
   margin-bottom: 1.25rem;
   align-items: flex-start;
 }
 
-[data-theme="classic"] .cp-flatlined__icon-wrap {
+[data-skin="classic"] .cp-flatlined__icon-wrap {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -371,14 +371,14 @@
   flex-shrink: 0;
 }
 
-[data-theme="classic"] .cp-flatlined__skull {
+[data-skin="classic"] .cp-flatlined__skull {
   width: 1.75rem;
   height: 1.75rem;
   color: #f87171;
   filter: none;
 }
 
-[data-theme="classic"] .cp-flatlined__title {
+[data-skin="classic"] .cp-flatlined__title {
   font-size: 1.35rem;
   font-weight: 800;
   letter-spacing: -0.02em;
@@ -388,7 +388,7 @@
   line-height: 1.25;
 }
 
-[data-theme="classic"] .cp-flatlined__deck {
+[data-skin="classic"] .cp-flatlined__deck {
   margin-top: 0.35rem;
   font-size: 0.7rem;
   letter-spacing: 0.06em;
@@ -396,26 +396,26 @@
   color: #a1a1aa;
 }
 
-[data-theme="classic"] .cp-flatlined__msg {
+[data-skin="classic"] .cp-flatlined__msg {
   font-size: 1.05rem;
   font-weight: 700;
   color: #fafafa;
   margin-bottom: 0.5rem;
 }
 
-[data-theme="classic"] .cp-flatlined__detail {
+[data-skin="classic"] .cp-flatlined__detail {
   color: #a1a1aa;
   font-size: 0.95rem;
   line-height: 1.55;
   margin-bottom: 1.5rem;
 }
 
-[data-theme="classic"] .cp-flatlined__detail strong {
+[data-skin="classic"] .cp-flatlined__detail strong {
   color: #0095ff;
   font-weight: 700;
 }
 
-[data-theme="classic"] .cp-flatlined__classic-btn {
+[data-skin="classic"] .cp-flatlined__classic-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -433,15 +433,15 @@
   transition: background 0.15s ease, transform 0.1s ease;
 }
 
-[data-theme="classic"] .cp-flatlined__classic-btn:hover {
+[data-skin="classic"] .cp-flatlined__classic-btn:hover {
   background: #33aaff;
 }
 
-[data-theme="classic"] .cp-flatlined__classic-btn:active {
+[data-skin="classic"] .cp-flatlined__classic-btn:active {
   transform: scale(0.98);
 }
 
-[data-theme="classic"] .cp-flatlined__menu-item {
+[data-skin="classic"] .cp-flatlined__menu-item {
   text-align: center;
   letter-spacing: 0.04em;
   text-transform: none;
@@ -450,17 +450,17 @@
   border-radius: 0.75rem;
 }
 
-[data-theme="classic"] .cp-flatlined__menu-item:hover {
+[data-skin="classic"] .cp-flatlined__menu-item:hover {
   color: #0095ff;
   border-color: rgba(0, 149, 255, 0.35);
   background: rgba(0, 149, 255, 0.06);
 }
 
 /* Hide any residual cyber chrome if class leaks */
-[data-theme="classic"] .cp-flatlined__rain,
-[data-theme="classic"] .cp-flatlined__scan,
-[data-theme="classic"] .cp-flatlined__vignette,
-[data-theme="classic"] .cp-flatlined__top,
-[data-theme="classic"] .cp-flatlined__foot {
+[data-skin="classic"] .cp-flatlined__rain,
+[data-skin="classic"] .cp-flatlined__scan,
+[data-skin="classic"] .cp-flatlined__vignette,
+[data-skin="classic"] .cp-flatlined__top,
+[data-skin="classic"] .cp-flatlined__foot {
   display: none !important;
 }

--- a/frontend/src/theme/theme-classic.css
+++ b/frontend/src/theme/theme-classic.css
@@ -19,6 +19,33 @@
   box-shadow: none !important;
 }
 
+/* Classic collapsed: circular-ish icon pills that fit the rail */
+[data-theme="classic"] .cp-sidebar--collapsed .cp-nav-item,
+[data-theme="classic"] .cp-sidebar .cp-nav-item.justify-center {
+  justify-content: center !important;
+  width: 2.75rem !important;
+  min-width: 2.75rem !important;
+  height: 2.75rem !important;
+  min-height: 2.75rem !important;
+  padding: 0 !important;
+  margin: 0 auto 0.35rem auto !important;
+  border-radius: 0.85rem !important;
+  gap: 0 !important;
+}
+
+[data-theme="classic"] .cp-sidebar--collapsed .cp-nav-item > span {
+  display: none !important;
+}
+
+[data-theme="classic"] .cp-sidebar--collapsed .cp-sidebar__toggle {
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 [data-theme="classic"] .cp-brand {
   letter-spacing: -0.02em !important;
   text-transform: none !important;
@@ -34,23 +61,62 @@
   border-radius: 0.75rem !important;
 }
 
-[data-theme="classic"] .cp-nav-item {
-  letter-spacing: 0.04em !important;
+/* Classic sidebar — original PS blue pill buttons */
+[data-theme="classic"] .cp-sidebar .cp-nav-item {
+  letter-spacing: -0.01em !important;
   border-radius: 1rem !important;
+  border: none !important;
   text-shadow: none !important;
+  padding: 1rem 1rem !important;
+  margin-bottom: 0.5rem !important;
+  gap: 1rem !important;
+  min-height: 3.25rem;
+  box-shadow: none !important;
+  font-family: system-ui, "Segoe UI", sans-serif !important;
 }
 
-[data-theme="classic"] .cp-nav-item.is-active {
-  color: #fff !important;
-  background: var(--color-ps-blue) !important;
+[data-theme="classic"] .cp-sidebar .cp-nav-item:not(.is-active) {
+  color: #a1a1aa !important;
+  background: transparent !important;
+}
+
+[data-theme="classic"] .cp-sidebar .cp-nav-item.is-active {
+  color: #ffffff !important;
+  background: #0095ff !important;
   border-color: transparent !important;
-  box-shadow: 0 0 20px var(--color-ps-blue-glow) !important;
+  box-shadow: 0 0 20px rgba(0, 149, 255, 0.35) !important;
   text-shadow: none !important;
 }
 
-[data-theme="classic"] .cp-nav-item:hover:not(.is-active) {
-  color: #fff !important;
+[data-theme="classic"] .cp-sidebar .cp-nav-item.is-active svg {
+  color: #ffffff !important;
+  filter: none !important;
+}
+
+[data-theme="classic"] .cp-sidebar .cp-nav-item:hover:not(.is-active) {
+  color: #ffffff !important;
   background: rgba(255, 255, 255, 0.05) !important;
+}
+
+[data-theme="classic"] .cp-sidebar .cp-nav-item.cp-nav-donate:not(.is-active) {
+  color: rgba(239, 68, 68, 0.7) !important;
+}
+
+[data-theme="classic"] .cp-sidebar .cp-nav-item.cp-nav-donate.is-active {
+  color: #ffffff !important;
+  background: #dc2626 !important;
+  box-shadow: 0 0 20px rgba(220, 38, 38, 0.3) !important;
+}
+
+/* Classic brand toggle shouldn't flash yellow (cyber accent) */
+[data-theme="classic"] .cp-sidebar__brand button {
+  border-radius: 0.75rem !important;
+  border: none !important;
+}
+
+[data-theme="classic"] .cp-sidebar__brand button:hover {
+  background: #0095ff !important;
+  color: #ffffff !important;
 }
 
 [data-theme="classic"] .glass-card {
@@ -100,6 +166,102 @@
   border-radius: 10px !important;
 }
 
+/*
+ * Classic .cp-btn fallbacks — when markup uses HudButton classes (e.g. <label>),
+ * still render as original rounded PS blue pills.
+ */
+[data-theme="classic"] .cp-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1.5rem;
+  border-radius: 1rem;
+  border: none;
+  background: #0095ff;
+  color: #fff;
+  font-weight: 700;
+  font-size: 1rem;
+  letter-spacing: -0.01em;
+  text-transform: none;
+  cursor: pointer;
+  transition: background 0.15s ease, transform 0.1s ease;
+}
+
+[data-theme="classic"] .cp-btn:hover {
+  background: rgba(0, 149, 255, 0.85);
+}
+
+[data-theme="classic"] .cp-btn--lg {
+  padding: 1.15rem 2.25rem;
+  font-size: 1.15rem;
+  border-radius: 1.25rem;
+}
+
+[data-theme="classic"] .cp-btn--sm {
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  border-radius: 0.75rem;
+}
+
+[data-theme="classic"] .cp-btn--primary {
+  background: #0095ff;
+  color: #fff;
+}
+
+[data-theme="classic"] .cp-btn--secondary,
+[data-theme="classic"] .cp-btn--ghost {
+  background: rgba(255, 255, 255, 0.05);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+[data-theme="classic"] .cp-btn--danger {
+  background: #dc2626;
+  color: #fff;
+}
+
+[data-theme="classic"] .cp-btn--dangerSoft {
+  background: rgba(239, 68, 68, 0.1);
+  color: #ef4444;
+  border: 1px solid rgba(239, 68, 68, 0.1);
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+}
+
+[data-theme="classic"] .cp-btn--success {
+  background: #059669;
+  color: #fff;
+}
+
+[data-theme="classic"] .cp-btn--block,
+[data-theme="classic"] .cp-btn--bar {
+  width: 100%;
+}
+
+[data-theme="classic"] .cp-btn__label {
+  font-weight: inherit;
+}
+
+/* Classic settings cards — soft blue hover (match original) */
+[data-theme="classic"] .setting-row {
+  border-radius: 1.5rem !important;
+}
+
+[data-theme="classic"] .setting-row:hover {
+  border-color: rgba(0, 149, 255, 0.3) !important;
+}
+
+[data-theme="classic"] .setting-row:hover .setting-row__icon {
+  background: rgba(0, 149, 255, 0.1) !important;
+  color: #0095ff !important;
+}
+
+[data-theme="classic"] .setting-row__title {
+  letter-spacing: -0.01em !important;
+  font-family: system-ui, "Segoe UI", sans-serif !important;
+}
+
 /* Classic never shows cyberpunk chrome (even if left in DOM) */
 [data-theme="classic"] .cp-atm,
 [data-theme="classic"] .cp-hudbar {
@@ -115,4 +277,40 @@
 [data-theme="classic"] nav.fixed.bottom-0 {
   border-top-color: rgba(255, 255, 255, 0.08) !important;
   background: rgba(8, 8, 10, 0.95) !important;
+}
+
+[data-theme="classic"] .cp-delay-card {
+  border-radius: 1.5rem !important;
+}
+
+[data-theme="classic"] .cp-btn.is-selected,
+[data-theme="classic"] .cp-btn--selected {
+  background: #0095ff !important;
+  color: #fff !important;
+  border-color: #0095ff !important;
+  transform: scale(1.02);
+}
+
+[data-theme="classic"] .cp-log-overlay {
+  background: #08080a;
+}
+
+[data-theme="classic"] .cp-log-overlay__header {
+  border-bottom-color: rgba(255, 255, 255, 0.08);
+  background: rgba(8, 8, 10, 0.96);
+}
+
+[data-theme="classic"] .cp-log-overlay__title h3 {
+  font-style: italic;
+  letter-spacing: -0.03em;
+  color: #fff;
+  text-shadow: none;
+}
+
+[data-theme="classic"] .cp-log-line:hover {
+  border-left-color: #0095ff;
+}
+
+[data-theme="classic"] .cp-log-line__prompt {
+  color: rgba(0, 149, 255, 0.85);
 }

--- a/frontend/src/theme/theme-classic.css
+++ b/frontend/src/theme/theme-classic.css
@@ -327,3 +327,24 @@
   background: rgba(0, 149, 255, 0.1);
   border-color: rgba(0, 149, 255, 0.25);
 }
+
+[data-theme="classic"] .cp-flatlined {
+  background: #08080a;
+}
+
+[data-theme="classic"] .cp-flatlined__panel {
+  border-radius: 1rem;
+  border-color: rgba(255, 255, 255, 0.1);
+  background: rgba(16, 16, 20, 0.9);
+}
+
+[data-theme="classic"] .cp-flatlined__title {
+  color: #ef4444;
+  text-shadow: none;
+  letter-spacing: -0.02em;
+}
+
+[data-theme="classic"] .cp-flatlined__skull {
+  color: #ef4444;
+  filter: none;
+}

--- a/frontend/src/theme/theme-cyberpunk.css
+++ b/frontend/src/theme/theme-cyberpunk.css
@@ -1,0 +1,559 @@
+/**
+ * CYBERPUNK theme only — Night City HUD.
+ * Scope: [data-theme="cyberpunk"]
+ * Classic must never import these visuals.
+ */
+
+[data-theme="cyberpunk"] .ps5-bg {
+  background-image:
+    radial-gradient(ellipse 70% 90% at 12% 40%, rgba(120, 12, 18, 0.4) 0%, transparent 55%),
+    radial-gradient(ellipse 50% 50% at 88% 30%, rgba(0, 60, 80, 0.15) 0%, transparent 50%),
+    radial-gradient(ellipse 80% 40% at 50% 100%, rgba(80, 10, 20, 0.18) 0%, transparent 55%),
+    linear-gradient(180deg, #0a080c 0%, #06050a 50%, #05040a 100%) !important;
+}
+
+[data-theme="cyberpunk"] .ps5-bg::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.04;
+  background-image:
+    linear-gradient(rgba(255, 60, 60, 0.5) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 60, 60, 0.5) 1px, transparent 1px);
+  background-size: 64px 64px;
+  mask-image: radial-gradient(ellipse 70% 70% at 50% 45%, black 20%, transparent 75%);
+  -webkit-mask-image: radial-gradient(ellipse 70% 70% at 50% 45%, black 20%, transparent 75%);
+}
+
+[data-theme="cyberpunk"] .cp-sidebar {
+  background: linear-gradient(
+    180deg,
+    rgba(40, 4, 8, 0.95) 0%,
+    rgba(12, 4, 8, 0.92) 50%,
+    rgba(8, 4, 10, 0.95) 100%
+  ) !important;
+  border-right: 1px solid rgba(255, 60, 60, 0.35) !important;
+  box-shadow:
+    4px 0 60px rgba(80, 0, 10, 0.35),
+    inset -1px 0 0 rgba(255, 60, 60, 0.08) !important;
+}
+
+[data-theme="cyberpunk"] .cp-brand {
+  letter-spacing: 0.18em !important;
+  text-transform: uppercase !important;
+  color: var(--color-ps-red) !important;
+  text-shadow: 0 0 18px rgba(255, 60, 60, 0.55) !important;
+}
+
+[data-theme="cyberpunk"] .cp-brand-icon {
+  background: transparent !important;
+  color: var(--color-ps-red) !important;
+  border: 1px solid rgba(255, 60, 60, 0.5) !important;
+  box-shadow: 0 0 16px rgba(255, 60, 60, 0.25) !important;
+  border-radius: 0.35rem !important;
+}
+
+/*
+ * Main-menu style nav (like CONTINUE):
+ * - idle: red text, no frame
+ * - active: cyan text + thin cyan rectangular frame only
+ * - no cursor chip / no heavy fill
+ */
+[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item {
+  letter-spacing: 0.16em !important;
+  border-radius: 0 !important;
+  border-width: 1px !important;
+  border-style: solid !important;
+  border-color: transparent !important;
+  background: transparent !important;
+  box-shadow: none !important;
+  text-shadow: none !important;
+  padding: 0.85rem 1.15rem !important;
+  min-height: 3rem;
+  gap: 0.85rem !important;
+  justify-content: flex-start !important;
+  width: 100% !important;
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease !important;
+}
+
+[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item:hover:not(.is-active) {
+  color: #ff9a9a !important;
+  background: transparent !important;
+  border-color: transparent !important;
+}
+
+[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item.is-active {
+  color: #00f0ff !important;
+  background: rgba(0, 240, 255, 0.04) !important;
+  border-color: #00f0ff !important;
+  box-shadow: none !important;
+  text-shadow: 0 0 12px rgba(0, 240, 255, 0.35) !important;
+}
+
+[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item.is-active svg {
+  color: #00f0ff !important;
+  filter: drop-shadow(0 0 4px rgba(0, 240, 255, 0.5));
+}
+
+[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item:not(.is-active) svg {
+  color: currentColor !important;
+  opacity: 0.9;
+}
+
+/* Collapsed rail: keep square frame around icon only */
+[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item.justify-center {
+  justify-content: center !important;
+  padding: 0.75rem !important;
+  width: auto !important;
+  min-width: 3rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+/* Donate uses same frame, warmer red when idle */
+[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item.cp-nav-donate:not(.is-active) {
+  color: rgba(255, 90, 90, 0.85) !important;
+}
+
+[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item.cp-nav-donate.is-active {
+  color: #ff6b6b !important;
+  border-color: #ff6b6b !important;
+  background: rgba(255, 60, 60, 0.06) !important;
+  text-shadow: 0 0 10px rgba(255, 60, 60, 0.35) !important;
+}
+
+[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item.cp-nav-donate.is-active svg {
+  color: #ff6b6b !important;
+  filter: drop-shadow(0 0 4px rgba(255, 60, 60, 0.45));
+}
+
+/* Mobile bottom nav cyberpunk */
+[data-theme="cyberpunk"] nav.fixed.bottom-0 .cp-nav-item {
+  letter-spacing: 0.08em !important;
+  border-radius: 0 !important;
+  border: 1px solid transparent !important;
+  background: transparent !important;
+}
+
+[data-theme="cyberpunk"] nav.fixed.bottom-0 .cp-nav-item.is-active {
+  color: #00f0ff !important;
+  border-color: #00f0ff !important;
+  background: rgba(0, 240, 255, 0.04) !important;
+  box-shadow: none !important;
+}
+
+/*
+ * Angular notch-cut panels + HUD reticle brackets (from amilarajans
+ * feature/cyberpunk-2077-theme). Classic stays fully rounded.
+ */
+[data-theme="cyberpunk"] .cp-clip,
+[data-theme="cyberpunk"] .glass-card,
+[data-theme="cyberpunk"] .glass-panel {
+  border-radius: 0 !important;
+  clip-path: polygon(
+    0 0,
+    calc(100% - 14px) 0,
+    100% 14px,
+    100% 100%,
+    14px 100%,
+    0 calc(100% - 14px)
+  );
+}
+
+[data-theme="cyberpunk"] .glass-card {
+  border: 1px solid rgba(255, 60, 60, 0.12) !important;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.3) !important;
+  position: relative;
+  overflow: visible;
+}
+
+[data-theme="cyberpunk"] .glass-card:hover,
+[data-theme="cyberpunk"] .glass-card:focus {
+  background: rgba(20, 10, 16, 0.95) !important;
+  border-color: rgba(0, 240, 255, 0.45) !important;
+  box-shadow: 0 0 24px rgba(0, 240, 255, 0.12) !important;
+}
+
+/* HUD targeting-reticle corner brackets — fade in on hover/focus */
+[data-theme="cyberpunk"] .glass-card::before,
+[data-theme="cyberpunk"] .glass-card::after {
+  content: "";
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--color-ps-yellow);
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  pointer-events: none;
+  z-index: 20;
+}
+
+[data-theme="cyberpunk"] .glass-card::before {
+  top: 3px;
+  left: 3px;
+  border-right: none;
+  border-bottom: none;
+}
+
+[data-theme="cyberpunk"] .glass-card::after {
+  bottom: 3px;
+  right: 3px;
+  border-left: none;
+  border-top: none;
+}
+
+[data-theme="cyberpunk"] .glass-card:hover::before,
+[data-theme="cyberpunk"] .glass-card:hover::after,
+[data-theme="cyberpunk"] .glass-card:focus::before,
+[data-theme="cyberpunk"] .glass-card:focus::after {
+  opacity: 1;
+}
+
+[data-theme="cyberpunk"] .glass-panel {
+  background: rgba(8, 4, 10, 0.75) !important;
+}
+
+/* Yellow hazard stripe — sidebar top chrome (hidden height 0 in classic) */
+.cp-hazard {
+  height: 0;
+  overflow: hidden;
+  transition: height 0.25s ease;
+}
+
+[data-theme="cyberpunk"] .cp-hazard {
+  height: 6px;
+  width: 100%;
+  background-image: repeating-linear-gradient(
+    135deg,
+    var(--color-ps-yellow) 0px,
+    var(--color-ps-yellow) 10px,
+    #0a0508 10px,
+    #0a0508 20px
+  );
+}
+
+/* Chromatic-aberration glitch text (cyan / magenta fringe) */
+.cp-glitch {
+  text-shadow: none;
+}
+
+[data-theme="cyberpunk"] .cp-glitch {
+  text-shadow:
+    -1px 0 var(--color-ps-blue),
+    1px 0 var(--color-ps-red);
+}
+
+/* Occasional flicker — loading overlay only, not persistent chrome */
+@keyframes cp-flicker {
+  0%, 91%, 100% { opacity: 1; transform: translateX(0); }
+  92% { opacity: 0.75; transform: translateX(-2px); }
+  93% { opacity: 1; transform: translateX(2px); }
+  94% { opacity: 0.85; transform: translateX(0); }
+}
+
+.cp-glitch-flicker {
+  animation: none;
+}
+
+[data-theme="cyberpunk"] .cp-glitch-flicker {
+  animation: cp-flicker 3.2s infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-theme="cyberpunk"] .cp-glitch-flicker {
+    animation: none;
+  }
+}
+
+[data-theme="cyberpunk"] .cp-progress-fill {
+  background: linear-gradient(90deg, #4a0010 0%, #ff3c3c 30%, #ff6a3a 55%, #fcee0a 85%, #fff6a0 100%) !important;
+  box-shadow: 0 0 16px rgba(252, 238, 10, 0.25) !important;
+}
+
+[data-theme="cyberpunk"] .cp-title-accent {
+  text-shadow: 0 0 14px rgba(255, 60, 60, 0.45) !important;
+}
+
+[data-theme="cyberpunk"] h1,
+[data-theme="cyberpunk"] h2,
+[data-theme="cyberpunk"] h3,
+[data-theme="cyberpunk"] h4 {
+  letter-spacing: 0.04em !important;
+  text-transform: uppercase !important;
+  font-style: italic;
+}
+
+[data-theme="cyberpunk"] .label-caps {
+  color: #7a6a68 !important;
+  letter-spacing: 0.14em !important;
+}
+
+[data-theme="cyberpunk"] .ps5-robust-spinner {
+  border: 8px solid rgba(255, 60, 60, 0.12) !important;
+  border-left-color: var(--color-ps-yellow) !important;
+  border-top-color: var(--color-ps-blue) !important;
+  box-shadow: 0 0 24px rgba(252, 238, 10, 0.15) !important;
+}
+
+[data-theme="cyberpunk"] ::-webkit-scrollbar-thumb,
+[data-theme="cyberpunk"] .custom-scrollbar::-webkit-scrollbar-thumb {
+  background: rgba(255, 60, 60, 0.35) !important;
+  border-radius: 2px !important;
+}
+
+[data-theme="cyberpunk"] nav.fixed.bottom-0 {
+  border-top-color: rgba(255, 60, 60, 0.3) !important;
+  background: rgba(10, 5, 8, 0.95) !important;
+}
+
+/* ── HUD bar (only rendered when cyberpunk, styled here) ── */
+[data-theme="cyberpunk"] .cp-hudbar {
+  position: relative;
+  flex-shrink: 0;
+  z-index: 120;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  min-height: 44px;
+  padding: 10px 20px;
+  font-family: var(--font-ui);
+  font-size: 11px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--color-hud);
+  border-bottom: 1px solid rgba(255, 60, 60, 0.35);
+  background: linear-gradient(180deg, rgba(40, 4, 8, 0.92) 0%, rgba(12, 4, 8, 0.88) 100%);
+  pointer-events: none;
+}
+
+[data-theme="cyberpunk"] .cp-hudbar__left,
+[data-theme="cyberpunk"] .cp-hudbar__right {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-shrink: 0;
+}
+
+[data-theme="cyberpunk"] .cp-hudbar__mid {
+  flex: 1;
+  text-align: center;
+  opacity: 0.7;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-theme="cyberpunk"] .cp-hudbar__stat {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+[data-theme="cyberpunk"] .cp-hudbar__num {
+  color: var(--color-ps-red);
+  font-weight: 800;
+  font-size: 13px;
+  text-shadow: 0 0 10px rgba(255, 60, 60, 0.4);
+}
+
+[data-theme="cyberpunk"] .cp-hudbar__stat--cyan .cp-hudbar__num {
+  color: var(--color-ps-blue);
+  text-shadow: 0 0 10px rgba(0, 240, 255, 0.4);
+}
+
+[data-theme="cyberpunk"] .cp-hudbar__label {
+  opacity: 0.65;
+  font-size: 10px;
+}
+
+[data-theme="cyberpunk"] .cp-hudbar__sep {
+  width: 1px;
+  height: 14px;
+  background: rgba(255, 60, 60, 0.35);
+}
+
+[data-theme="cyberpunk"] .cp-hudbar__meta {
+  color: rgba(255, 100, 100, 0.55);
+  font-size: 10px;
+}
+
+[data-theme="cyberpunk"] .cp-hudbar__meta--cyan {
+  color: rgba(0, 240, 255, 0.55);
+}
+
+[data-theme="cyberpunk"] .cp-hudbar__protocol {
+  font-size: 10px;
+  letter-spacing: 0.2em;
+}
+
+/* ── Atmosphere ── */
+[data-theme="cyberpunk"] .cp-atm {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  overflow: hidden;
+  opacity: 1;
+}
+
+[data-theme="cyberpunk"] .cp-atm__haze {
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(90deg, rgba(90, 8, 14, 0.55) 0%, transparent 38%, transparent 62%, rgba(40, 8, 20, 0.25) 100%),
+    radial-gradient(ellipse 90% 70% at 50% 40%, transparent 25%, rgba(0, 0, 0, 0.45) 100%);
+}
+
+[data-theme="cyberpunk"] .cp-atm__grid {
+  position: absolute;
+  inset: 0;
+  opacity: 0.07;
+  background-image:
+    linear-gradient(rgba(255, 60, 60, 0.55) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 60, 60, 0.55) 1px, transparent 1px);
+  background-size: 48px 48px;
+}
+
+[data-theme="cyberpunk"] .cp-atm__vignette {
+  position: absolute;
+  inset: 0;
+  box-shadow: inset 0 0 180px 40px rgba(0, 0, 0, 0.55);
+}
+
+[data-theme="cyberpunk"] .cp-atm__scanlines {
+  position: absolute;
+  inset: 0;
+  opacity: 0.25;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0, 0, 0, 0.12) 2px,
+    rgba(0, 0, 0, 0.12) 4px
+  );
+}
+
+[data-theme="cyberpunk"] .cp-atm__rain {
+  position: absolute;
+  inset: 0;
+  opacity: 0.22;
+  mask-image: linear-gradient(90deg, transparent 0%, black 20%, black 80%, transparent 100%);
+  -webkit-mask-image: linear-gradient(90deg, transparent 0%, black 20%, black 80%, transparent 100%);
+}
+
+[data-theme="cyberpunk"] .cp-atm__col {
+  position: absolute;
+  top: -20%;
+  width: 5.5%;
+  margin: 0;
+  font-family: Consolas, "Courier New", monospace;
+  font-size: 11px;
+  line-height: 1.45;
+  letter-spacing: 0.06em;
+  color: rgba(255, 70, 70, 0.55);
+  white-space: pre;
+  animation: cp-atm-fall linear infinite;
+}
+
+[data-theme="cyberpunk"] .cp-atm__col--2 { color: rgba(255, 60, 60, 0.35); font-size: 10px; }
+[data-theme="cyberpunk"] .cp-atm__col--3 { color: rgba(180, 40, 50, 0.4); }
+
+@keyframes cp-atm-fall {
+  0% { transform: translateY(0); opacity: 0; }
+  8% { opacity: 0.7; }
+  92% { opacity: 0.4; }
+  100% { transform: translateY(140%); opacity: 0; }
+}
+
+/* Corner chips removed — they clipped headers / card top borders */
+
+/*
+ * OFF | ON segmented toggle (settings UI reference)
+ * Angular ends, dim OFF side, solid cyan ON side when selected.
+ */
+[data-theme="cyberpunk"] .cp-toggle {
+  display: inline-flex;
+  align-items: stretch;
+  width: 9.5rem;
+  height: 2.25rem;
+  padding: 0;
+  border: 1px solid rgba(255, 60, 60, 0.35);
+  background: rgba(8, 2, 6, 0.9);
+  cursor: pointer;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+@media (min-width: 768px) {
+  [data-theme="cyberpunk"] .cp-toggle {
+    width: 11rem;
+    height: 2.6rem;
+  }
+}
+
+[data-theme="cyberpunk"] .cp-toggle__seg {
+  flex: 1 1 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-ui);
+  font-size: 0.7rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  line-height: 1;
+  transition: background 0.15s ease, color 0.15s ease, text-shadow 0.15s ease;
+  user-select: none;
+}
+
+@media (min-width: 768px) {
+  [data-theme="cyberpunk"] .cp-toggle__seg {
+    font-size: 0.8rem;
+  }
+}
+
+/* Left OFF slab — angled cut on the right */
+[data-theme="cyberpunk"] .cp-toggle__seg--off {
+  color: rgba(255, 90, 90, 0.45);
+  background: rgba(50, 12, 18, 0.85);
+  clip-path: polygon(0 0, 100% 0, 88% 100%, 0 100%);
+  margin-right: -0.45rem;
+  z-index: 1;
+}
+
+/* Right ON slab — angled cut on the left */
+[data-theme="cyberpunk"] .cp-toggle__seg--on {
+  color: rgba(0, 240, 255, 0.4);
+  background: rgba(10, 20, 24, 0.75);
+  clip-path: polygon(12% 0, 100% 0, 100% 100%, 0 100%);
+  margin-left: -0.45rem;
+  z-index: 2;
+}
+
+[data-theme="cyberpunk"] .cp-toggle__seg--off.is-selected {
+  color: #0a0508;
+  background: #ff4a4a;
+  text-shadow: none;
+}
+
+[data-theme="cyberpunk"] .cp-toggle__seg--on.is-selected {
+  color: #0a0508;
+  background: #00f0ff;
+  text-shadow: none;
+  box-shadow: 0 0 16px rgba(0, 240, 255, 0.35);
+}
+
+/* When OFF is selected, dim the ON side more */
+[data-theme="cyberpunk"] .cp-toggle.is-off .cp-toggle__seg--on {
+  color: rgba(0, 200, 210, 0.28);
+  background: rgba(8, 14, 18, 0.65);
+}
+
+/* When ON is selected, dim the OFF side */
+[data-theme="cyberpunk"] .cp-toggle.is-on .cp-toggle__seg--off {
+  color: rgba(255, 90, 90, 0.4);
+  background: rgba(40, 8, 14, 0.9);
+}

--- a/frontend/src/theme/theme-cyberpunk.css
+++ b/frontend/src/theme/theme-cyberpunk.css
@@ -1,10 +1,10 @@
 /**
  * CYBERPUNK theme only — Night City HUD.
- * Scope: [data-theme="cyberpunk"]
+ * Scope: [data-skin="cyberpunk"]
  * Classic must never import these visuals.
  */
 
-[data-theme="cyberpunk"] .ps5-bg {
+[data-skin="cyberpunk"] .ps5-bg {
   background-image:
     radial-gradient(ellipse 70% 90% at 12% 40%, rgba(120, 12, 18, 0.4) 0%, transparent 55%),
     radial-gradient(ellipse 50% 50% at 88% 30%, rgba(0, 60, 80, 0.15) 0%, transparent 50%),
@@ -12,7 +12,7 @@
     linear-gradient(180deg, #0a080c 0%, #06050a 50%, #05040a 100%) !important;
 }
 
-[data-theme="cyberpunk"] .ps5-bg::before {
+[data-skin="cyberpunk"] .ps5-bg::before {
   content: '';
   position: fixed;
   inset: 0;
@@ -27,7 +27,7 @@
   -webkit-mask-image: radial-gradient(ellipse 70% 70% at 50% 45%, black 20%, transparent 75%);
 }
 
-[data-theme="cyberpunk"] .cp-sidebar {
+[data-skin="cyberpunk"] .cp-sidebar {
   background: linear-gradient(
     180deg,
     rgba(40, 4, 8, 0.95) 0%,
@@ -40,14 +40,14 @@
     inset -1px 0 0 rgba(255, 60, 60, 0.08) !important;
 }
 
-[data-theme="cyberpunk"] .cp-brand {
+[data-skin="cyberpunk"] .cp-brand {
   letter-spacing: 0.18em !important;
   text-transform: uppercase !important;
   color: var(--color-ps-red) !important;
   text-shadow: 0 0 18px rgba(255, 60, 60, 0.55) !important;
 }
 
-[data-theme="cyberpunk"] .cp-brand-icon {
+[data-skin="cyberpunk"] .cp-brand-icon {
   background: transparent !important;
   color: var(--color-ps-red) !important;
   border: 1px solid rgba(255, 60, 60, 0.5) !important;
@@ -59,11 +59,11 @@
  * Sidebar nav — same cut shape as payload cards:
  * only bottom-right cut, stroke on the diagonal, yellow corners on hover.
  */
-[data-theme="cyberpunk"] .cp-sidebar__nav {
+[data-skin="cyberpunk"] .cp-sidebar__nav {
   gap: 0.35rem !important;
 }
 
-[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item {
+[data-skin="cyberpunk"] .cp-sidebar .cp-nav-item {
   --cp-cut: 14px;
   --cp-edge: transparent;
   --cp-fill: transparent;
@@ -101,31 +101,31 @@
   transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease !important;
 }
 
-[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item:hover:not(.is-active) {
+[data-skin="cyberpunk"] .cp-sidebar .cp-nav-item:hover:not(.is-active) {
   --cp-edge: rgba(255, 60, 60, 0.6);
   --cp-fill: rgba(255, 60, 60, 0.05);
   color: #ff9a9a !important;
 }
 
-[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item.is-active {
+[data-skin="cyberpunk"] .cp-sidebar .cp-nav-item.is-active {
   --cp-edge: #00f0ff;
   --cp-fill: rgba(0, 240, 255, 0.06);
   color: #00f0ff !important;
   text-shadow: 0 0 12px rgba(0, 240, 255, 0.35) !important;
 }
 
-[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item.is-active svg {
+[data-skin="cyberpunk"] .cp-sidebar .cp-nav-item.is-active svg {
   color: #00f0ff !important;
   filter: drop-shadow(0 0 4px rgba(0, 240, 255, 0.5));
 }
 
-[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item:not(.is-active) svg {
+[data-skin="cyberpunk"] .cp-sidebar .cp-nav-item:not(.is-active) svg {
   color: currentColor !important;
   opacity: 0.9;
 }
 
 /* Yellow L-ticks on 3 corners (TL / TR / BL) — nav hover + active */
-[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item::before {
+[data-skin="cyberpunk"] .cp-sidebar .cp-nav-item::before {
   content: "";
   position: absolute;
   inset: 0;
@@ -158,14 +158,14 @@
     left 4px bottom 4px;
 }
 
-[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item:hover::before,
-[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item.is-active::before {
+[data-skin="cyberpunk"] .cp-sidebar .cp-nav-item:hover::before,
+[data-skin="cyberpunk"] .cp-sidebar .cp-nav-item.is-active::before {
   opacity: 1;
 }
 
 /* Collapsed rail: icon tiles with same BR cut */
-[data-theme="cyberpunk"] .cp-sidebar--collapsed .cp-nav-item,
-[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item.justify-center {
+[data-skin="cyberpunk"] .cp-sidebar--collapsed .cp-nav-item,
+[data-skin="cyberpunk"] .cp-sidebar .cp-nav-item.justify-center {
   --cp-cut: 8px;
   justify-content: center !important;
   align-items: center !important;
@@ -181,15 +181,15 @@
   overflow: hidden !important;
 }
 
-[data-theme="cyberpunk"] .cp-sidebar--collapsed .cp-nav-item svg,
-[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item.justify-center svg {
+[data-skin="cyberpunk"] .cp-sidebar--collapsed .cp-nav-item svg,
+[data-skin="cyberpunk"] .cp-sidebar .cp-nav-item.justify-center svg {
   width: 1.25rem !important;
   height: 1.25rem !important;
   flex-shrink: 0;
 }
 
 /* Hide label box entirely when collapsed so it can't steal width */
-[data-theme="cyberpunk"] .cp-sidebar--collapsed .cp-nav-item > span {
+[data-skin="cyberpunk"] .cp-sidebar--collapsed .cp-nav-item > span {
   display: none !important;
   width: 0 !important;
   opacity: 0 !important;
@@ -199,7 +199,7 @@
 }
 
 /* Hamburger — yellow hover (not PS blue) */
-[data-theme="cyberpunk"] .cp-sidebar__toggle {
+[data-skin="cyberpunk"] .cp-sidebar__toggle {
   border: 1px solid rgba(255, 60, 60, 0.28);
   border-radius: 0.35rem;
   color: rgba(255, 90, 90, 0.85);
@@ -207,15 +207,15 @@
   transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
-[data-theme="cyberpunk"] .cp-sidebar__toggle:hover,
-[data-theme="cyberpunk"] .cp-sidebar__toggle:focus-visible {
+[data-skin="cyberpunk"] .cp-sidebar__toggle:hover,
+[data-skin="cyberpunk"] .cp-sidebar__toggle:focus-visible {
   color: #0a0508 !important;
   background: var(--color-ps-yellow, #fcee0a) !important;
   border-color: var(--color-ps-yellow, #fcee0a) !important;
   box-shadow: 0 0 16px rgba(252, 238, 10, 0.35);
 }
 
-[data-theme="cyberpunk"] .cp-sidebar--collapsed .cp-sidebar__toggle {
+[data-skin="cyberpunk"] .cp-sidebar--collapsed .cp-sidebar__toggle {
   width: 2.75rem;
   height: 2.75rem;
   padding: 0;
@@ -225,31 +225,31 @@
 }
 
 /* Donate uses same frame, warmer red when idle */
-[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item.cp-nav-donate:not(.is-active) {
+[data-skin="cyberpunk"] .cp-sidebar .cp-nav-item.cp-nav-donate:not(.is-active) {
   color: rgba(255, 90, 90, 0.85) !important;
 }
 
-[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item.cp-nav-donate.is-active {
+[data-skin="cyberpunk"] .cp-sidebar .cp-nav-item.cp-nav-donate.is-active {
   color: #ff6b6b !important;
   border-color: #ff6b6b !important;
   background: rgba(255, 60, 60, 0.06) !important;
   text-shadow: 0 0 10px rgba(255, 60, 60, 0.35) !important;
 }
 
-[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item.cp-nav-donate.is-active svg {
+[data-skin="cyberpunk"] .cp-sidebar .cp-nav-item.cp-nav-donate.is-active svg {
   color: #ff6b6b !important;
   filter: drop-shadow(0 0 4px rgba(255, 60, 60, 0.45));
 }
 
 /* Mobile bottom nav cyberpunk */
-[data-theme="cyberpunk"] nav.fixed.bottom-0 .cp-nav-item {
+[data-skin="cyberpunk"] nav.fixed.bottom-0 .cp-nav-item {
   letter-spacing: 0.08em !important;
   border-radius: 0 !important;
   border: 1px solid transparent !important;
   background: transparent !important;
 }
 
-[data-theme="cyberpunk"] nav.fixed.bottom-0 .cp-nav-item.is-active {
+[data-skin="cyberpunk"] nav.fixed.bottom-0 .cp-nav-item.is-active {
   color: #00f0ff !important;
   border-color: #00f0ff !important;
   background: rgba(0, 240, 255, 0.04) !important;
@@ -268,9 +268,9 @@
  *        │              /
  *        └─────────────/   ← stroke on this edge
  */
-[data-theme="cyberpunk"] .cp-clip,
-[data-theme="cyberpunk"] .glass-card,
-[data-theme="cyberpunk"] .glass-panel {
+[data-skin="cyberpunk"] .cp-clip,
+[data-skin="cyberpunk"] .glass-card,
+[data-skin="cyberpunk"] .glass-panel {
   --cp-cut: 16px;
   --cp-edge: rgba(255, 60, 60, 0.45);
   --cp-fill: var(--color-ps-card);
@@ -298,13 +298,13 @@
   background-repeat: no-repeat !important;
 }
 
-[data-theme="cyberpunk"] .glass-card {
+[data-skin="cyberpunk"] .glass-card {
   position: relative;
   overflow: hidden;
 }
 
-[data-theme="cyberpunk"] .glass-card:hover,
-[data-theme="cyberpunk"] .glass-card:focus {
+[data-skin="cyberpunk"] .glass-card:hover,
+[data-skin="cyberpunk"] .glass-card:focus {
   --cp-edge: rgba(0, 240, 255, 0.75);
   --cp-fill: rgba(20, 10, 16, 0.95);
   border-color: var(--cp-edge) !important;
@@ -320,7 +320,7 @@
  * Use left/right/bottom background-position so TR and BL
  * place correctly (calc(100%-N) was mis-aligning those).
  */
-[data-theme="cyberpunk"] .glass-card::before {
+[data-skin="cyberpunk"] .glass-card::before {
   content: "";
   position: absolute;
   inset: 0;
@@ -356,18 +356,18 @@
     left 5px bottom 5px;
 }
 
-[data-theme="cyberpunk"] .glass-card::after {
+[data-skin="cyberpunk"] .glass-card::after {
   content: none;
   display: none;
 }
 
-[data-theme="cyberpunk"] .glass-card:hover::before,
-[data-theme="cyberpunk"] .glass-card:focus::before {
+[data-skin="cyberpunk"] .glass-card:hover::before,
+[data-skin="cyberpunk"] .glass-card:focus::before {
   opacity: 1;
   filter: drop-shadow(0 0 3px rgba(252, 238, 10, 0.65));
 }
 
-[data-theme="cyberpunk"] .glass-panel {
+[data-skin="cyberpunk"] .glass-panel {
   --cp-fill: rgba(8, 4, 10, 0.75);
 }
 
@@ -378,7 +378,7 @@
   transition: height 0.25s ease;
 }
 
-[data-theme="cyberpunk"] .cp-hazard {
+[data-skin="cyberpunk"] .cp-hazard {
   height: 6px;
   width: 100%;
   background-image: repeating-linear-gradient(
@@ -395,7 +395,7 @@
   text-shadow: none;
 }
 
-[data-theme="cyberpunk"] .cp-glitch {
+[data-skin="cyberpunk"] .cp-glitch {
   text-shadow:
     -1px 0 var(--color-ps-blue),
     1px 0 var(--color-ps-red);
@@ -413,59 +413,59 @@
   animation: none;
 }
 
-[data-theme="cyberpunk"] .cp-glitch-flicker {
+[data-skin="cyberpunk"] .cp-glitch-flicker {
   animation: cp-flicker 3.2s infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  [data-theme="cyberpunk"] .cp-glitch-flicker {
+  [data-skin="cyberpunk"] .cp-glitch-flicker {
     animation: none;
   }
 }
 
-[data-theme="cyberpunk"] .cp-progress-fill {
+[data-skin="cyberpunk"] .cp-progress-fill {
   background: linear-gradient(90deg, #4a0010 0%, #ff3c3c 30%, #ff6a3a 55%, #fcee0a 85%, #fff6a0 100%) !important;
   box-shadow: 0 0 16px rgba(252, 238, 10, 0.25) !important;
 }
 
-[data-theme="cyberpunk"] .cp-title-accent {
+[data-skin="cyberpunk"] .cp-title-accent {
   text-shadow: 0 0 14px rgba(255, 60, 60, 0.45) !important;
 }
 
-[data-theme="cyberpunk"] h1,
-[data-theme="cyberpunk"] h2,
-[data-theme="cyberpunk"] h3,
-[data-theme="cyberpunk"] h4 {
+[data-skin="cyberpunk"] h1,
+[data-skin="cyberpunk"] h2,
+[data-skin="cyberpunk"] h3,
+[data-skin="cyberpunk"] h4 {
   letter-spacing: 0.04em !important;
   text-transform: uppercase !important;
   font-style: italic;
 }
 
-[data-theme="cyberpunk"] .label-caps {
+[data-skin="cyberpunk"] .label-caps {
   color: #7a6a68 !important;
   letter-spacing: 0.14em !important;
 }
 
-[data-theme="cyberpunk"] .ps5-robust-spinner {
+[data-skin="cyberpunk"] .ps5-robust-spinner {
   border: 8px solid rgba(255, 60, 60, 0.12) !important;
   border-left-color: var(--color-ps-yellow) !important;
   border-top-color: var(--color-ps-blue) !important;
   box-shadow: 0 0 24px rgba(252, 238, 10, 0.15) !important;
 }
 
-[data-theme="cyberpunk"] ::-webkit-scrollbar-thumb,
-[data-theme="cyberpunk"] .custom-scrollbar::-webkit-scrollbar-thumb {
+[data-skin="cyberpunk"] ::-webkit-scrollbar-thumb,
+[data-skin="cyberpunk"] .custom-scrollbar::-webkit-scrollbar-thumb {
   background: rgba(255, 60, 60, 0.35) !important;
   border-radius: 2px !important;
 }
 
-[data-theme="cyberpunk"] nav.fixed.bottom-0 {
+[data-skin="cyberpunk"] nav.fixed.bottom-0 {
   border-top-color: rgba(255, 60, 60, 0.3) !important;
   background: rgba(10, 5, 8, 0.95) !important;
 }
 
 /* ── HUD bar (only rendered when cyberpunk, styled here) ── */
-[data-theme="cyberpunk"] .cp-hudbar {
+[data-skin="cyberpunk"] .cp-hudbar {
   position: relative;
   flex-shrink: 0;
   z-index: 120;
@@ -485,15 +485,15 @@
   pointer-events: none;
 }
 
-[data-theme="cyberpunk"] .cp-hudbar__left,
-[data-theme="cyberpunk"] .cp-hudbar__right {
+[data-skin="cyberpunk"] .cp-hudbar__left,
+[data-skin="cyberpunk"] .cp-hudbar__right {
   display: flex;
   align-items: center;
   gap: 14px;
   flex-shrink: 0;
 }
 
-[data-theme="cyberpunk"] .cp-hudbar__mid {
+[data-skin="cyberpunk"] .cp-hudbar__mid {
   flex: 1;
   text-align: center;
   opacity: 0.7;
@@ -502,51 +502,51 @@
   white-space: nowrap;
 }
 
-[data-theme="cyberpunk"] .cp-hudbar__stat {
+[data-skin="cyberpunk"] .cp-hudbar__stat {
   display: inline-flex;
   align-items: baseline;
   gap: 8px;
 }
 
-[data-theme="cyberpunk"] .cp-hudbar__num {
+[data-skin="cyberpunk"] .cp-hudbar__num {
   color: var(--color-ps-red);
   font-weight: 800;
   font-size: 13px;
   text-shadow: 0 0 10px rgba(255, 60, 60, 0.4);
 }
 
-[data-theme="cyberpunk"] .cp-hudbar__stat--cyan .cp-hudbar__num {
+[data-skin="cyberpunk"] .cp-hudbar__stat--cyan .cp-hudbar__num {
   color: var(--color-ps-blue);
   text-shadow: 0 0 10px rgba(0, 240, 255, 0.4);
 }
 
-[data-theme="cyberpunk"] .cp-hudbar__label {
+[data-skin="cyberpunk"] .cp-hudbar__label {
   opacity: 0.65;
   font-size: 10px;
 }
 
-[data-theme="cyberpunk"] .cp-hudbar__sep {
+[data-skin="cyberpunk"] .cp-hudbar__sep {
   width: 1px;
   height: 14px;
   background: rgba(255, 60, 60, 0.35);
 }
 
-[data-theme="cyberpunk"] .cp-hudbar__meta {
+[data-skin="cyberpunk"] .cp-hudbar__meta {
   color: rgba(255, 100, 100, 0.55);
   font-size: 10px;
 }
 
-[data-theme="cyberpunk"] .cp-hudbar__meta--cyan {
+[data-skin="cyberpunk"] .cp-hudbar__meta--cyan {
   color: rgba(0, 240, 255, 0.55);
 }
 
-[data-theme="cyberpunk"] .cp-hudbar__protocol {
+[data-skin="cyberpunk"] .cp-hudbar__protocol {
   font-size: 10px;
   letter-spacing: 0.2em;
 }
 
 /* ── Atmosphere ── */
-[data-theme="cyberpunk"] .cp-atm {
+[data-skin="cyberpunk"] .cp-atm {
   position: fixed;
   inset: 0;
   z-index: 0;
@@ -555,7 +555,7 @@
   opacity: 1;
 }
 
-[data-theme="cyberpunk"] .cp-atm__haze {
+[data-skin="cyberpunk"] .cp-atm__haze {
   position: absolute;
   inset: 0;
   background:
@@ -563,7 +563,7 @@
     radial-gradient(ellipse 90% 70% at 50% 40%, transparent 25%, rgba(0, 0, 0, 0.45) 100%);
 }
 
-[data-theme="cyberpunk"] .cp-atm__grid {
+[data-skin="cyberpunk"] .cp-atm__grid {
   position: absolute;
   inset: 0;
   opacity: 0.07;
@@ -573,13 +573,13 @@
   background-size: 48px 48px;
 }
 
-[data-theme="cyberpunk"] .cp-atm__vignette {
+[data-skin="cyberpunk"] .cp-atm__vignette {
   position: absolute;
   inset: 0;
   box-shadow: inset 0 0 180px 40px rgba(0, 0, 0, 0.55);
 }
 
-[data-theme="cyberpunk"] .cp-atm__scanlines {
+[data-skin="cyberpunk"] .cp-atm__scanlines {
   position: absolute;
   inset: 0;
   opacity: 0.25;
@@ -592,7 +592,7 @@
   );
 }
 
-[data-theme="cyberpunk"] .cp-atm__rain {
+[data-skin="cyberpunk"] .cp-atm__rain {
   position: absolute;
   inset: 0;
   opacity: 0.22;
@@ -600,7 +600,7 @@
   -webkit-mask-image: linear-gradient(90deg, transparent 0%, black 20%, black 80%, transparent 100%);
 }
 
-[data-theme="cyberpunk"] .cp-atm__col {
+[data-skin="cyberpunk"] .cp-atm__col {
   position: absolute;
   top: -20%;
   width: 5.5%;
@@ -614,8 +614,8 @@
   animation: cp-atm-fall linear infinite;
 }
 
-[data-theme="cyberpunk"] .cp-atm__col--2 { color: rgba(255, 60, 60, 0.35); font-size: 10px; }
-[data-theme="cyberpunk"] .cp-atm__col--3 { color: rgba(180, 40, 50, 0.4); }
+[data-skin="cyberpunk"] .cp-atm__col--2 { color: rgba(255, 60, 60, 0.35); font-size: 10px; }
+[data-skin="cyberpunk"] .cp-atm__col--3 { color: rgba(180, 40, 50, 0.4); }
 
 @keyframes cp-atm-fall {
   0% { transform: translateY(0); opacity: 0; }
@@ -627,29 +627,29 @@
 /* Corner chips removed — they clipped headers / card top borders */
 
 /* Settings cards — cyberpunk chrome (angular, not crushed copy) */
-[data-theme="cyberpunk"] .setting-row {
+[data-skin="cyberpunk"] .setting-row {
   border-radius: 0.35rem !important;
   border-color: rgba(255, 60, 60, 0.18) !important;
   background: rgba(18, 6, 10, 0.72) !important;
 }
 
-[data-theme="cyberpunk"] .setting-row:hover {
+[data-skin="cyberpunk"] .setting-row:hover {
   border-color: rgba(0, 240, 255, 0.35) !important;
 }
 
-[data-theme="cyberpunk"] .setting-row__title {
+[data-skin="cyberpunk"] .setting-row__title {
   /* Mono + huge tracking made "Multiple Payload Sources" wrap word-by-word */
   letter-spacing: 0.06em !important;
   font-style: normal !important;
   line-height: 1.35 !important;
 }
 
-[data-theme="cyberpunk"] .setting-row__desc {
+[data-skin="cyberpunk"] .setting-row__desc {
   color: #7a6a68 !important;
   letter-spacing: 0.01em !important;
 }
 
-[data-theme="cyberpunk"] .setting-row__icon {
+[data-skin="cyberpunk"] .setting-row__icon {
   border-radius: 0.35rem !important;
   border: 1px solid rgba(255, 60, 60, 0.2);
   color: rgba(255, 90, 90, 0.65) !important;
@@ -660,7 +660,7 @@
  * Angular ends, dim OFF side, solid cyan ON side when selected.
  * Slightly narrower so it coexists with long titles in half-width cards.
  */
-[data-theme="cyberpunk"] .cp-toggle {
+[data-skin="cyberpunk"] .cp-toggle {
   display: inline-flex;
   align-items: stretch;
   width: 8.25rem;
@@ -674,13 +674,13 @@
 }
 
 @media (min-width: 768px) {
-  [data-theme="cyberpunk"] .cp-toggle {
+  [data-skin="cyberpunk"] .cp-toggle {
     width: 9.5rem;
     height: 2.45rem;
   }
 }
 
-[data-theme="cyberpunk"] .cp-toggle__seg {
+[data-skin="cyberpunk"] .cp-toggle__seg {
   flex: 1 1 50%;
   display: flex;
   align-items: center;
@@ -696,13 +696,13 @@
 }
 
 @media (min-width: 768px) {
-  [data-theme="cyberpunk"] .cp-toggle__seg {
+  [data-skin="cyberpunk"] .cp-toggle__seg {
     font-size: 0.8rem;
   }
 }
 
 /* Left OFF slab — angled cut on the right */
-[data-theme="cyberpunk"] .cp-toggle__seg--off {
+[data-skin="cyberpunk"] .cp-toggle__seg--off {
   color: rgba(255, 90, 90, 0.45);
   background: rgba(50, 12, 18, 0.85);
   clip-path: polygon(0 0, 100% 0, 88% 100%, 0 100%);
@@ -711,7 +711,7 @@
 }
 
 /* Right ON slab — angled cut on the left */
-[data-theme="cyberpunk"] .cp-toggle__seg--on {
+[data-skin="cyberpunk"] .cp-toggle__seg--on {
   color: rgba(0, 240, 255, 0.4);
   background: rgba(10, 20, 24, 0.75);
   clip-path: polygon(12% 0, 100% 0, 100% 100%, 0 100%);
@@ -719,13 +719,13 @@
   z-index: 2;
 }
 
-[data-theme="cyberpunk"] .cp-toggle__seg--off.is-selected {
+[data-skin="cyberpunk"] .cp-toggle__seg--off.is-selected {
   color: #0a0508;
   background: #ff4a4a;
   text-shadow: none;
 }
 
-[data-theme="cyberpunk"] .cp-toggle__seg--on.is-selected {
+[data-skin="cyberpunk"] .cp-toggle__seg--on.is-selected {
   color: #0a0508;
   background: #00f0ff;
   text-shadow: none;
@@ -733,13 +733,13 @@
 }
 
 /* When OFF is selected, dim the ON side more */
-[data-theme="cyberpunk"] .cp-toggle.is-off .cp-toggle__seg--on {
+[data-skin="cyberpunk"] .cp-toggle.is-off .cp-toggle__seg--on {
   color: rgba(0, 200, 210, 0.28);
   background: rgba(8, 14, 18, 0.65);
 }
 
 /* When ON is selected, dim the OFF side */
-[data-theme="cyberpunk"] .cp-toggle.is-on .cp-toggle__seg--off {
+[data-skin="cyberpunk"] .cp-toggle.is-on .cp-toggle__seg--off {
   color: rgba(255, 90, 90, 0.4);
   background: rgba(40, 8, 14, 0.9);
 }
@@ -750,7 +750,7 @@
  * Match in-game CRAFTING / INVENTORY / MAP / DATABASE bar tiles.
  * ═══════════════════════════════════════════════════════════════════ */
 
-[data-theme="cyberpunk"] .cp-btn {
+[data-skin="cyberpunk"] .cp-btn {
   position: relative;
   display: inline-flex;
   align-items: center;
@@ -782,8 +782,8 @@
   -webkit-tap-highlight-color: transparent;
 }
 
-[data-theme="cyberpunk"] .cp-btn:hover:not(:disabled),
-[data-theme="cyberpunk"] .cp-btn:focus-visible:not(:disabled) {
+[data-skin="cyberpunk"] .cp-btn:hover:not(:disabled),
+[data-skin="cyberpunk"] .cp-btn:focus-visible:not(:disabled) {
   color: #00f0ff;
   border-color: #00f0ff;
   background:
@@ -793,27 +793,27 @@
     inset 0 0 0 1px rgba(0, 240, 255, 0.18);
 }
 
-[data-theme="cyberpunk"] .cp-btn:active:not(:disabled) {
+[data-skin="cyberpunk"] .cp-btn:active:not(:disabled) {
   transform: translateY(1px);
 }
 
-[data-theme="cyberpunk"] .cp-btn:disabled {
+[data-skin="cyberpunk"] .cp-btn:disabled {
   opacity: 0.35;
   cursor: not-allowed;
   filter: grayscale(0.3);
 }
 
-[data-theme="cyberpunk"] .cp-btn__icon {
+[data-skin="cyberpunk"] .cp-btn__icon {
   flex-shrink: 0;
   color: currentColor;
 }
 
-[data-theme="cyberpunk"] .cp-btn__label {
+[data-skin="cyberpunk"] .cp-btn__label {
   white-space: nowrap;
 }
 
 /* Primary — selected MAP-style cyan frame */
-[data-theme="cyberpunk"] .cp-btn--primary {
+[data-skin="cyberpunk"] .cp-btn--primary {
   border-color: rgba(0, 240, 255, 0.55);
   color: #00f0ff;
   background:
@@ -823,8 +823,8 @@
     0 0 12px rgba(0, 240, 255, 0.08);
 }
 
-[data-theme="cyberpunk"] .cp-btn--primary:hover:not(:disabled),
-[data-theme="cyberpunk"] .cp-btn--primary:focus-visible:not(:disabled) {
+[data-skin="cyberpunk"] .cp-btn--primary:hover:not(:disabled),
+[data-skin="cyberpunk"] .cp-btn--primary:focus-visible:not(:disabled) {
   border-color: #00f0ff;
   color: #00f0ff;
   background:
@@ -835,26 +835,26 @@
 }
 
 /* Secondary / Cancel — dim red frame like idle CRAFTING */
-[data-theme="cyberpunk"] .cp-btn--secondary {
+[data-skin="cyberpunk"] .cp-btn--secondary {
   border-color: rgba(255, 60, 60, 0.32);
   color: rgba(255, 120, 120, 0.8);
   background: rgba(24, 6, 10, 0.7);
 }
 
-[data-theme="cyberpunk"] .cp-btn--secondary:hover:not(:disabled) {
+[data-skin="cyberpunk"] .cp-btn--secondary:hover:not(:disabled) {
   border-color: rgba(0, 240, 255, 0.55);
   color: #00f0ff;
   background: rgba(0, 40, 48, 0.35);
 }
 
 /* Danger — Kill / Delete / Abort */
-[data-theme="cyberpunk"] .cp-btn--danger {
+[data-skin="cyberpunk"] .cp-btn--danger {
   border-color: rgba(255, 60, 60, 0.65);
   color: #ff6b6b;
   background: linear-gradient(90deg, rgba(70, 8, 12, 0.85) 0%, rgba(40, 6, 10, 0.75) 100%);
 }
 
-[data-theme="cyberpunk"] .cp-btn--danger:hover:not(:disabled) {
+[data-skin="cyberpunk"] .cp-btn--danger:hover:not(:disabled) {
   border-color: #ff3c3c;
   color: #fff;
   background: rgba(255, 40, 50, 0.28);
@@ -862,7 +862,7 @@
 }
 
 /* Soft danger — icon row delete */
-[data-theme="cyberpunk"] .cp-btn--dangerSoft {
+[data-skin="cyberpunk"] .cp-btn--dangerSoft {
   border-color: rgba(255, 60, 60, 0.28);
   color: #ff6b6b;
   background: rgba(40, 6, 10, 0.45);
@@ -870,42 +870,42 @@
   padding: 0.5rem 0.75rem;
 }
 
-[data-theme="cyberpunk"] .cp-btn--dangerSoft:hover:not(:disabled) {
+[data-skin="cyberpunk"] .cp-btn--dangerSoft:hover:not(:disabled) {
   border-color: #ff3c3c;
   color: #fff;
   background: rgba(255, 50, 60, 0.25);
 }
 
 /* Success — Update */
-[data-theme="cyberpunk"] .cp-btn--success {
+[data-skin="cyberpunk"] .cp-btn--success {
   border-color: rgba(0, 240, 255, 0.45);
   color: #7dffc8;
   background:
     linear-gradient(90deg, rgba(0, 40, 30, 0.55) 0%, rgba(0, 50, 55, 0.4) 100%);
 }
 
-[data-theme="cyberpunk"] .cp-btn--success:hover:not(:disabled) {
+[data-skin="cyberpunk"] .cp-btn--success:hover:not(:disabled) {
   border-color: #00f0ff;
   color: #00f0ff;
   box-shadow: 0 0 18px rgba(0, 240, 255, 0.18);
 }
 
 /* Ghost — dashed idle / secondary actions */
-[data-theme="cyberpunk"] .cp-btn--ghost {
+[data-skin="cyberpunk"] .cp-btn--ghost {
   border-style: solid;
   border-color: rgba(255, 60, 60, 0.22);
   color: rgba(255, 100, 100, 0.7);
   background: transparent;
 }
 
-[data-theme="cyberpunk"] .cp-btn--ghost:hover:not(:disabled) {
+[data-skin="cyberpunk"] .cp-btn--ghost:hover:not(:disabled) {
   border-color: rgba(0, 240, 255, 0.5);
   color: #00f0ff;
   background: rgba(0, 240, 255, 0.05);
 }
 
 /* Sizes */
-[data-theme="cyberpunk"] .cp-btn--sm {
+[data-skin="cyberpunk"] .cp-btn--sm {
   min-height: 2.15rem;
   padding: 0.45rem 0.9rem;
   font-size: 0.68rem;
@@ -913,7 +913,7 @@
   gap: 0.45rem;
 }
 
-[data-theme="cyberpunk"] .cp-btn--lg {
+[data-skin="cyberpunk"] .cp-btn--lg {
   min-height: 3.5rem;
   padding: 1rem 1.75rem;
   font-size: 0.95rem;
@@ -921,12 +921,12 @@
   gap: 0.85rem;
 }
 
-[data-theme="cyberpunk"] .cp-btn--block {
+[data-skin="cyberpunk"] .cp-btn--block {
   width: 100%;
 }
 
 /* Icon-only square (trash, chevrons in rows) */
-[data-theme="cyberpunk"] .cp-btn--icon {
+[data-skin="cyberpunk"] .cp-btn--icon {
   min-width: 2.5rem;
   min-height: 2.5rem;
   padding: 0.5rem;
@@ -934,7 +934,7 @@
 }
 
 /* Full-width menu bar tiles (autoload enable, overlay actions) */
-[data-theme="cyberpunk"] .cp-btn--bar {
+[data-skin="cyberpunk"] .cp-btn--bar {
   width: 100%;
   min-height: 3.75rem;
   justify-content: flex-start;
@@ -945,26 +945,26 @@
 }
 
 /* Bar rows with trailing arrow (Autoload available payloads) */
-[data-theme="cyberpunk"] .cp-btn--with-end,
-[data-theme="cyberpunk"] .cp-btn--bar.cp-btn--with-end {
+[data-skin="cyberpunk"] .cp-btn--with-end,
+[data-skin="cyberpunk"] .cp-btn--bar.cp-btn--with-end {
   justify-content: space-between;
   text-align: left;
 }
 
-[data-theme="cyberpunk"] .cp-btn__end {
+[data-skin="cyberpunk"] .cp-btn__end {
   margin-left: auto;
   opacity: 0.55;
   transition: opacity 0.15s ease, transform 0.15s ease, color 0.15s ease;
 }
 
-[data-theme="cyberpunk"] .cp-btn:hover:not(:disabled) .cp-btn__end,
-[data-theme="cyberpunk"] .cp-btn:focus-visible:not(:disabled) .cp-btn__end {
+[data-skin="cyberpunk"] .cp-btn:hover:not(:disabled) .cp-btn__end,
+[data-skin="cyberpunk"] .cp-btn:focus-visible:not(:disabled) .cp-btn__end {
   opacity: 1;
   color: #00f0ff;
   transform: translateX(4px);
 }
 
-[data-theme="cyberpunk"] .cp-btn__body {
+[data-skin="cyberpunk"] .cp-btn__body {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
@@ -974,8 +974,8 @@
 }
 
 /* Selected chip (Autoload Delay 3s/5s/10s) */
-[data-theme="cyberpunk"] .cp-btn--selected,
-[data-theme="cyberpunk"] .cp-btn.is-selected {
+[data-skin="cyberpunk"] .cp-btn--selected,
+[data-skin="cyberpunk"] .cp-btn.is-selected {
   border-color: #00f0ff !important;
   color: #00f0ff !important;
   background:
@@ -985,13 +985,13 @@
     inset 0 0 0 1px rgba(0, 240, 255, 0.25) !important;
 }
 
-[data-theme="cyberpunk"] .cp-delay-card {
+[data-skin="cyberpunk"] .cp-delay-card {
   border-radius: 0.35rem !important;
   border-color: rgba(255, 60, 60, 0.18) !important;
   background: rgba(18, 6, 10, 0.72) !important;
 }
 
-[data-theme="cyberpunk"] .cp-delay-card__value {
+[data-skin="cyberpunk"] .cp-delay-card__value {
   color: #00f0ff;
   text-shadow: 0 0 14px rgba(0, 240, 255, 0.35);
   font-family: var(--font-ui);
@@ -999,7 +999,7 @@
   letter-spacing: 0.08em;
 }
 
-[data-theme="cyberpunk"] .cp-btn--payload-row {
+[data-skin="cyberpunk"] .cp-btn--payload-row {
   min-height: 4rem;
   padding-top: 1rem;
   padding-bottom: 1rem;
@@ -1007,17 +1007,17 @@
 }
 
 /* Log overlay — Night City terminal */
-[data-theme="cyberpunk"] .cp-log-overlay {
+[data-skin="cyberpunk"] .cp-log-overlay {
   background: #0a0508;
 }
 
-[data-theme="cyberpunk"] .cp-log-overlay__header {
+[data-skin="cyberpunk"] .cp-log-overlay__header {
   border-bottom-color: rgba(255, 60, 60, 0.35);
   background: linear-gradient(180deg, rgba(40, 4, 8, 0.96) 0%, rgba(12, 4, 8, 0.94) 100%);
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.45);
 }
 
-[data-theme="cyberpunk"] .cp-log-overlay__title h3 {
+[data-skin="cyberpunk"] .cp-log-overlay__title h3 {
   font-family: var(--font-ui);
   font-style: normal;
   letter-spacing: 0.18em;
@@ -1025,39 +1025,39 @@
   text-shadow: 0 0 16px rgba(255, 60, 60, 0.4);
 }
 
-[data-theme="cyberpunk"] .cp-log-viewer {
+[data-skin="cyberpunk"] .cp-log-viewer {
   background:
     linear-gradient(180deg, rgba(12, 4, 8, 0.5) 0%, rgba(6, 2, 6, 0.85) 100%);
 }
 
-[data-theme="cyberpunk"] .cp-log-viewer__scroll {
+[data-skin="cyberpunk"] .cp-log-viewer__scroll {
   font-family: var(--font-ui);
   letter-spacing: 0.02em;
 }
 
-[data-theme="cyberpunk"] .cp-log-line:hover {
+[data-skin="cyberpunk"] .cp-log-line:hover {
   background: rgba(0, 240, 255, 0.04);
   border-left-color: #00f0ff;
 }
 
-[data-theme="cyberpunk"] .cp-log-line__num {
+[data-skin="cyberpunk"] .cp-log-line__num {
   color: rgba(255, 80, 80, 0.45);
 }
 
-[data-theme="cyberpunk"] .cp-log-line__prompt {
+[data-skin="cyberpunk"] .cp-log-line__prompt {
   color: #00f0ff;
   text-shadow: 0 0 8px rgba(0, 240, 255, 0.35);
 }
 
-[data-theme="cyberpunk"] .cp-log-line__text {
+[data-skin="cyberpunk"] .cp-log-line__text {
   color: #e8e4e0;
 }
 
-[data-theme="cyberpunk"] .cp-log-viewer__empty {
+[data-skin="cyberpunk"] .cp-log-viewer__empty {
   color: #7a6a68;
 }
 
-[data-theme="cyberpunk"] .cp-autoload-off__panel {
+[data-skin="cyberpunk"] .cp-autoload-off__panel {
   border-radius: 0 !important;
   border-color: rgba(255, 60, 60, 0.3) !important;
   background:
@@ -1075,7 +1075,7 @@
   );
 }
 
-[data-theme="cyberpunk"] .cp-autoload-off__icon {
+[data-skin="cyberpunk"] .cp-autoload-off__icon {
   border-radius: 0 !important;
   border-color: rgba(0, 240, 255, 0.45) !important;
   background: rgba(0, 240, 255, 0.06) !important;
@@ -1083,25 +1083,25 @@
   box-shadow: 0 0 20px rgba(0, 240, 255, 0.12);
 }
 
-[data-theme="cyberpunk"] .cp-autoload-off__title {
+[data-skin="cyberpunk"] .cp-autoload-off__title {
   font-family: var(--font-ui);
   font-style: normal;
   letter-spacing: 0.1em;
   text-transform: uppercase;
 }
 
-[data-theme="cyberpunk"] .cp-autoload-off__desc {
+[data-skin="cyberpunk"] .cp-autoload-off__desc {
   color: #7a6a68;
   letter-spacing: 0.02em;
 }
 
-[data-theme="cyberpunk"] .cp-autoload-off__status {
+[data-skin="cyberpunk"] .cp-autoload-off__status {
   color: rgba(255, 90, 90, 0.75);
   letter-spacing: 0.18em;
 }
 
 /* FLATLINED — cyberpunk intensifies the death-menu look */
-[data-theme="cyberpunk"] .cp-flatlined,
+[data-skin="cyberpunk"] .cp-flatlined,
 .cp-flatlined--cyber {
   background:
     radial-gradient(ellipse 80% 60% at 20% 40%, rgba(120, 0, 20, 0.35) 0%, transparent 55%),
@@ -1109,7 +1109,7 @@
   font-family: var(--font-ui);
 }
 
-[data-theme="cyberpunk"] .cp-flatlined__panel,
+[data-skin="cyberpunk"] .cp-flatlined__panel,
 .cp-flatlined--cyber .cp-flatlined__panel {
   clip-path: polygon(
     0 0,
@@ -1121,13 +1121,13 @@
   border-color: rgba(255, 60, 60, 0.5);
 }
 
-[data-theme="cyberpunk"] .cp-flatlined__title,
+[data-skin="cyberpunk"] .cp-flatlined__title,
 .cp-flatlined--cyber .cp-flatlined__title {
   font-family: var(--font-display), var(--font-ui);
   letter-spacing: 0.12em;
 }
 
-[data-theme="cyberpunk"] .cp-flatlined__primary.cp-btn,
+[data-skin="cyberpunk"] .cp-flatlined__primary.cp-btn,
 .cp-flatlined--cyber .cp-flatlined__primary.cp-btn {
   border-color: #00f0ff !important;
   color: #00f0ff !important;
@@ -1136,14 +1136,14 @@
 
 /* ── Autoload overlay — Night City (matches rest of cyberpunk shell) ── */
 
-[data-theme="cyberpunk"].cp-autoload-overlay,
-[data-theme="cyberpunk"] .cp-autoload-overlay {
+[data-skin="cyberpunk"].cp-autoload-overlay,
+[data-skin="cyberpunk"] .cp-autoload-overlay {
   font-family: var(--font-ui);
   /* ps5-bg gradients apply when class is present; reinforce void base */
   background-color: #0a0508 !important;
 }
 
-[data-theme="cyberpunk"] .cp-autoload-overlay__warn {
+[data-skin="cyberpunk"] .cp-autoload-overlay__warn {
   border-radius: 0;
   clip-path: polygon(
     0 0,
@@ -1159,23 +1159,23 @@
   box-shadow: 0 0 20px rgba(252, 238, 10, 0.08);
 }
 
-[data-theme="cyberpunk"] .cp-autoload-overlay__eyebrow {
+[data-skin="cyberpunk"] .cp-autoload-overlay__eyebrow {
   letter-spacing: 0.28em;
   color: #00f0ff;
   text-shadow: 0 0 16px rgba(0, 240, 255, 0.4);
   font-style: italic;
 }
 
-[data-theme="cyberpunk"] .cp-autoload-overlay__ring-track {
+[data-skin="cyberpunk"] .cp-autoload-overlay__ring-track {
   color: rgba(255, 60, 60, 0.12);
 }
 
-[data-theme="cyberpunk"] .cp-autoload-overlay__ring-fill {
+[data-skin="cyberpunk"] .cp-autoload-overlay__ring-fill {
   color: #00f0ff;
   filter: drop-shadow(0 0 8px rgba(0, 240, 255, 0.45));
 }
 
-[data-theme="cyberpunk"] .cp-autoload-overlay__ring-num {
+[data-skin="cyberpunk"] .cp-autoload-overlay__ring-num {
   font-family: var(--font-ui);
   letter-spacing: 0.06em;
   text-shadow:
@@ -1183,14 +1183,14 @@
     1px 0 rgba(0, 240, 255, 0.55);
 }
 
-[data-theme="cyberpunk"] .cp-autoload-overlay__hint {
+[data-skin="cyberpunk"] .cp-autoload-overlay__hint {
   color: #7a6a68;
   letter-spacing: 0.18em;
   font-style: normal;
 }
 
 /* Done badge — angular cyan, not soft green pill */
-[data-theme="cyberpunk"] .cp-autoload-overlay__done-icon {
+[data-skin="cyberpunk"] .cp-autoload-overlay__done-icon {
   border-radius: 0;
   padding: 1.75rem;
   color: #0a0508;
@@ -1208,7 +1208,7 @@
   );
 }
 
-[data-theme="cyberpunk"] .cp-autoload-overlay__done-title {
+[data-skin="cyberpunk"] .cp-autoload-overlay__done-title {
   font-family: var(--font-ui);
   font-style: italic;
   letter-spacing: 0.12em;
@@ -1220,14 +1220,14 @@
 }
 
 /* Payload list panel */
-[data-theme="cyberpunk"] .cp-autoload-overlay__list {
+[data-skin="cyberpunk"] .cp-autoload-overlay__list {
   border-radius: 0 !important;
   /* glass-card BR cut already applied via class; reinforce fill */
   background: rgba(12, 4, 8, 0.82) !important;
   gap: 0.75rem;
 }
 
-[data-theme="cyberpunk"] .cp-autoload-overlay__list-head {
+[data-skin="cyberpunk"] .cp-autoload-overlay__list-head {
   border-radius: 0;
   background: linear-gradient(180deg, rgba(40, 4, 8, 0.9) 0%, rgba(12, 4, 8, 0.75) 100%);
   border-bottom: 1px solid rgba(255, 60, 60, 0.28);
@@ -1237,13 +1237,13 @@
   padding-right: 0.75rem;
 }
 
-[data-theme="cyberpunk"] .cp-autoload-overlay__list-head .label-caps {
+[data-skin="cyberpunk"] .cp-autoload-overlay__list-head .label-caps {
   color: #ff3c3c !important;
   letter-spacing: 0.2em !important;
   text-shadow: 0 0 12px rgba(255, 60, 60, 0.35);
 }
 
-[data-theme="cyberpunk"] .cp-autoload-overlay__count {
+[data-skin="cyberpunk"] .cp-autoload-overlay__count {
   border-radius: 0.2rem;
   background: rgba(0, 240, 255, 0.1);
   border: 1px solid rgba(0, 240, 255, 0.35);
@@ -1251,56 +1251,56 @@
   letter-spacing: 0.12em;
 }
 
-[data-theme="cyberpunk"] .cp-autoload-overlay__item {
+[data-skin="cyberpunk"] .cp-autoload-overlay__item {
   border-radius: 0 !important;
   /* nested glass-card inherits BR cut */
   opacity: 1;
 }
 
-[data-theme="cyberpunk"] .cp-autoload-overlay__item.is-pending {
+[data-skin="cyberpunk"] .cp-autoload-overlay__item.is-pending {
   opacity: 0.45;
   --cp-edge: rgba(255, 60, 60, 0.2);
   --cp-fill: rgba(12, 4, 8, 0.5);
 }
 
-[data-theme="cyberpunk"] .cp-autoload-overlay__item.is-active {
+[data-skin="cyberpunk"] .cp-autoload-overlay__item.is-active {
   --cp-edge: #00f0ff;
   --cp-fill: rgba(0, 240, 255, 0.08);
   transform: scale(1.02);
   box-shadow: 0 0 24px rgba(0, 240, 255, 0.15) !important;
 }
 
-[data-theme="cyberpunk"] .cp-autoload-overlay__item.is-done {
+[data-skin="cyberpunk"] .cp-autoload-overlay__item.is-done {
   --cp-edge: rgba(0, 240, 255, 0.4);
   --cp-fill: rgba(0, 40, 45, 0.35);
   background-color: rgba(0, 40, 45, 0.35) !important;
   border-color: rgba(0, 240, 255, 0.4) !important;
 }
 
-[data-theme="cyberpunk"] .cp-autoload-overlay__item-icon.is-done {
+[data-skin="cyberpunk"] .cp-autoload-overlay__item-icon.is-done {
   color: #00f0ff;
   filter: drop-shadow(0 0 6px rgba(0, 240, 255, 0.5));
 }
 
-[data-theme="cyberpunk"] .cp-autoload-overlay__item-icon.is-active {
+[data-skin="cyberpunk"] .cp-autoload-overlay__item-icon.is-active {
   color: #fcee0a;
   filter: drop-shadow(0 0 6px rgba(252, 238, 10, 0.45));
 }
 
-[data-theme="cyberpunk"] .cp-autoload-overlay__item-icon.is-pending {
+[data-skin="cyberpunk"] .cp-autoload-overlay__item-icon.is-pending {
   border-radius: 0;
   border-color: rgba(255, 60, 60, 0.35);
   background: transparent;
 }
 
-[data-theme="cyberpunk"] .cp-autoload-overlay__item-tag {
+[data-skin="cyberpunk"] .cp-autoload-overlay__item-tag {
   color: #00f0ff;
   font-style: normal;
   letter-spacing: 0.18em;
   text-shadow: 0 0 8px rgba(0, 240, 255, 0.35);
 }
 
-[data-theme="cyberpunk"] .cp-autoload-overlay__dots span {
+[data-skin="cyberpunk"] .cp-autoload-overlay__dots span {
   border-radius: 0;
   background: #00f0ff;
   box-shadow: 0 0 8px rgba(0, 240, 255, 0.5);

--- a/frontend/src/theme/theme-cyberpunk.css
+++ b/frontend/src/theme/theme-cyberpunk.css
@@ -56,22 +56,33 @@
 }
 
 /*
- * Main-menu style nav (like CONTINUE):
- * - idle: red text, no frame
- * - active: cyan text + thin cyan rectangular frame only
- * - no cursor chip / no heavy fill
+ * Sidebar nav — same cut shape as payload cards:
+ * only bottom-right cut, stroke on the diagonal, yellow corners on hover.
  */
 [data-theme="cyberpunk"] .cp-sidebar__nav {
-  gap: 0.15rem !important;
+  gap: 0.35rem !important;
 }
 
 [data-theme="cyberpunk"] .cp-sidebar .cp-nav-item {
+  --cp-cut: 14px;
+  --cp-edge: transparent;
+  --cp-fill: transparent;
+  position: relative !important;
+  overflow: hidden !important;
   letter-spacing: 0.16em !important;
   border-radius: 0 !important;
-  border-width: 1px !important;
-  border-style: solid !important;
-  border-color: transparent !important;
-  background: transparent !important;
+  border: 1px solid var(--cp-edge) !important;
+  background-color: var(--cp-fill) !important;
+  background-image: linear-gradient(
+    135deg,
+    transparent calc(50% - 0.75px),
+    var(--cp-edge) calc(50% - 0.75px),
+    var(--cp-edge) calc(50% + 0.75px),
+    transparent calc(50% + 0.75px)
+  ) !important;
+  background-size: var(--cp-cut) var(--cp-cut) !important;
+  background-position: right bottom !important;
+  background-repeat: no-repeat !important;
   box-shadow: none !important;
   text-shadow: none !important;
   padding: 0.85rem 1.15rem !important;
@@ -80,20 +91,26 @@
   gap: 0.85rem !important;
   justify-content: flex-start !important;
   width: 100% !important;
-  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease !important;
+  clip-path: polygon(
+    0 0,
+    100% 0,
+    100% calc(100% - var(--cp-cut)),
+    calc(100% - var(--cp-cut)) 100%,
+    0 100%
+  );
+  transition: color 0.15s ease, border-color 0.15s ease, background-color 0.15s ease !important;
 }
 
 [data-theme="cyberpunk"] .cp-sidebar .cp-nav-item:hover:not(.is-active) {
+  --cp-edge: rgba(255, 60, 60, 0.6);
+  --cp-fill: rgba(255, 60, 60, 0.05);
   color: #ff9a9a !important;
-  background: transparent !important;
-  border-color: transparent !important;
 }
 
 [data-theme="cyberpunk"] .cp-sidebar .cp-nav-item.is-active {
+  --cp-edge: #00f0ff;
+  --cp-fill: rgba(0, 240, 255, 0.06);
   color: #00f0ff !important;
-  background: rgba(0, 240, 255, 0.04) !important;
-  border-color: #00f0ff !important;
-  box-shadow: none !important;
   text-shadow: 0 0 12px rgba(0, 240, 255, 0.35) !important;
 }
 
@@ -107,9 +124,49 @@
   opacity: 0.9;
 }
 
-/* Collapsed rail: square icon tiles that fully fit (no clipped borders) */
+/* Yellow L-ticks on 3 corners (TL / TR / BL) — nav hover + active */
+[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  pointer-events: none;
+  z-index: 5;
+  transition: opacity 0.15s ease;
+  background-repeat: no-repeat;
+  background-image:
+    linear-gradient(#fcee0a, #fcee0a),
+    linear-gradient(#fcee0a, #fcee0a),
+    linear-gradient(#fcee0a, #fcee0a),
+    linear-gradient(#fcee0a, #fcee0a),
+    linear-gradient(#fcee0a, #fcee0a),
+    linear-gradient(#fcee0a, #fcee0a);
+  background-size:
+    2px 12px,
+    12px 2px,
+    2px 12px,
+    12px 2px,
+    2px 12px,
+    12px 2px;
+  /* left/right/bottom keywords so TR + BL place correctly */
+  background-position:
+    left 4px top 4px,
+    left 4px top 4px,
+    right 4px top 4px,
+    right 4px top 4px,
+    left 4px bottom 4px,
+    left 4px bottom 4px;
+}
+
+[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item:hover::before,
+[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item.is-active::before {
+  opacity: 1;
+}
+
+/* Collapsed rail: icon tiles with same BR cut */
 [data-theme="cyberpunk"] .cp-sidebar--collapsed .cp-nav-item,
 [data-theme="cyberpunk"] .cp-sidebar .cp-nav-item.justify-center {
+  --cp-cut: 8px;
   justify-content: center !important;
   align-items: center !important;
   padding: 0 !important;
@@ -121,7 +178,7 @@
   margin: 0 auto !important;
   gap: 0 !important;
   box-sizing: border-box !important;
-  overflow: visible !important;
+  overflow: hidden !important;
 }
 
 [data-theme="cyberpunk"] .cp-sidebar--collapsed .cp-nav-item svg,
@@ -141,12 +198,27 @@
   padding: 0 !important;
 }
 
+/* Hamburger — yellow hover (not PS blue) */
+[data-theme="cyberpunk"] .cp-sidebar__toggle {
+  border: 1px solid rgba(255, 60, 60, 0.28);
+  border-radius: 0.35rem;
+  color: rgba(255, 90, 90, 0.85);
+  background: rgba(255, 255, 255, 0.04);
+  transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
+}
+
+[data-theme="cyberpunk"] .cp-sidebar__toggle:hover,
+[data-theme="cyberpunk"] .cp-sidebar__toggle:focus-visible {
+  color: #0a0508 !important;
+  background: var(--color-ps-yellow, #fcee0a) !important;
+  border-color: var(--color-ps-yellow, #fcee0a) !important;
+  box-shadow: 0 0 16px rgba(252, 238, 10, 0.35);
+}
+
 [data-theme="cyberpunk"] .cp-sidebar--collapsed .cp-sidebar__toggle {
   width: 2.75rem;
   height: 2.75rem;
   padding: 0;
-  border: 1px solid rgba(255, 60, 60, 0.28);
-  border-radius: 0.35rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -185,74 +257,118 @@
 }
 
 /*
- * Angular notch-cut panels + HUD reticle brackets (from amilarajans
- * feature/cyberpunk-2077-theme). Classic stays fully rounded.
+ * Angular panels — ONLY bottom-right corner cut.
+ * Other 3 corners stay clean 90°.
+ *
+ * CSS border is clipped away on the diagonal, so we paint the cut
+ * edge with a 135° gradient in the BR corner square.
+ *
+ *        ┌──────────────┐
+ *        │              │
+ *        │              /
+ *        └─────────────/   ← stroke on this edge
  */
 [data-theme="cyberpunk"] .cp-clip,
 [data-theme="cyberpunk"] .glass-card,
 [data-theme="cyberpunk"] .glass-panel {
+  --cp-cut: 16px;
+  --cp-edge: rgba(255, 60, 60, 0.45);
+  --cp-fill: var(--color-ps-card);
   border-radius: 0 !important;
   clip-path: polygon(
     0 0,
-    calc(100% - 14px) 0,
-    100% 14px,
-    100% 100%,
-    14px 100%,
-    0 calc(100% - 14px)
+    100% 0,
+    100% calc(100% - var(--cp-cut)),
+    calc(100% - var(--cp-cut)) 100%,
+    0 100%
   );
+  border: 1px solid var(--cp-edge) !important;
+  box-shadow: none !important;
+  /* Fill + diagonal stroke on the cutout */
+  background-color: var(--cp-fill) !important;
+  background-image: linear-gradient(
+    135deg,
+    transparent calc(50% - 0.7px),
+    var(--cp-edge) calc(50% - 0.7px),
+    var(--cp-edge) calc(50% + 0.7px),
+    transparent calc(50% + 0.7px)
+  ) !important;
+  background-size: var(--cp-cut) var(--cp-cut) !important;
+  background-position: 100% 100% !important;
+  background-repeat: no-repeat !important;
 }
 
 [data-theme="cyberpunk"] .glass-card {
-  border: 1px solid rgba(255, 60, 60, 0.12) !important;
-  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.3) !important;
   position: relative;
-  overflow: visible;
+  overflow: hidden;
 }
 
 [data-theme="cyberpunk"] .glass-card:hover,
 [data-theme="cyberpunk"] .glass-card:focus {
-  background: rgba(20, 10, 16, 0.95) !important;
-  border-color: rgba(0, 240, 255, 0.45) !important;
-  box-shadow: 0 0 24px rgba(0, 240, 255, 0.12) !important;
+  --cp-edge: rgba(0, 240, 255, 0.75);
+  --cp-fill: rgba(20, 10, 16, 0.95);
+  border-color: var(--cp-edge) !important;
+  box-shadow: 0 0 20px rgba(0, 240, 255, 0.1) !important;
 }
 
-/* HUD targeting-reticle corner brackets — fade in on hover/focus */
-[data-theme="cyberpunk"] .glass-card::before,
-[data-theme="cyberpunk"] .glass-card::after {
+/*
+ * Yellow corner highlights on hover — 3 intact corners only:
+ *   TL ─── TR
+ *   │
+ *   BL         (BR = cut, no tick)
+ *
+ * Use left/right/bottom background-position so TR and BL
+ * place correctly (calc(100%-N) was mis-aligning those).
+ */
+[data-theme="cyberpunk"] .glass-card::before {
   content: "";
   position: absolute;
-  width: 14px;
-  height: 14px;
-  border: 2px solid var(--color-ps-yellow);
+  inset: 0;
+  width: auto;
+  height: auto;
+  border: none;
+  box-shadow: none;
   opacity: 0;
-  transition: opacity 0.2s ease;
   pointer-events: none;
   z-index: 20;
-}
-
-[data-theme="cyberpunk"] .glass-card::before {
-  top: 3px;
-  left: 3px;
-  border-right: none;
-  border-bottom: none;
+  transition: opacity 0.18s ease;
+  background-repeat: no-repeat;
+  background-image:
+    linear-gradient(#fcee0a, #fcee0a),
+    linear-gradient(#fcee0a, #fcee0a),
+    linear-gradient(#fcee0a, #fcee0a),
+    linear-gradient(#fcee0a, #fcee0a),
+    linear-gradient(#fcee0a, #fcee0a),
+    linear-gradient(#fcee0a, #fcee0a);
+  background-size:
+    2px 16px,
+    16px 2px,
+    2px 16px,
+    16px 2px,
+    2px 16px,
+    16px 2px;
+  background-position:
+    left 5px top 5px,
+    left 5px top 5px,
+    right 5px top 5px,
+    right 5px top 5px,
+    left 5px bottom 5px,
+    left 5px bottom 5px;
 }
 
 [data-theme="cyberpunk"] .glass-card::after {
-  bottom: 3px;
-  right: 3px;
-  border-left: none;
-  border-top: none;
+  content: none;
+  display: none;
 }
 
 [data-theme="cyberpunk"] .glass-card:hover::before,
-[data-theme="cyberpunk"] .glass-card:hover::after,
-[data-theme="cyberpunk"] .glass-card:focus::before,
-[data-theme="cyberpunk"] .glass-card:focus::after {
+[data-theme="cyberpunk"] .glass-card:focus::before {
   opacity: 1;
+  filter: drop-shadow(0 0 3px rgba(252, 238, 10, 0.65));
 }
 
 [data-theme="cyberpunk"] .glass-panel {
-  background: rgba(8, 4, 10, 0.75) !important;
+  --cp-fill: rgba(8, 4, 10, 0.75);
 }
 
 /* Yellow hazard stripe — sidebar top chrome (hidden height 0 in classic) */
@@ -939,4 +1055,47 @@
 
 [data-theme="cyberpunk"] .cp-log-viewer__empty {
   color: #7a6a68;
+}
+
+[data-theme="cyberpunk"] .cp-autoload-off__panel {
+  border-radius: 0 !important;
+  border-color: rgba(255, 60, 60, 0.3) !important;
+  background:
+    linear-gradient(180deg, rgba(40, 6, 10, 0.75) 0%, rgba(12, 4, 8, 0.9) 100%) !important;
+  box-shadow:
+    0 0 40px rgba(80, 0, 10, 0.25),
+    inset 0 0 0 1px rgba(0, 0, 0, 0.35);
+  clip-path: polygon(
+    0 0,
+    calc(100% - 18px) 0,
+    100% 18px,
+    100% 100%,
+    18px 100%,
+    0 calc(100% - 18px)
+  );
+}
+
+[data-theme="cyberpunk"] .cp-autoload-off__icon {
+  border-radius: 0 !important;
+  border-color: rgba(0, 240, 255, 0.45) !important;
+  background: rgba(0, 240, 255, 0.06) !important;
+  color: #00f0ff !important;
+  box-shadow: 0 0 20px rgba(0, 240, 255, 0.12);
+}
+
+[data-theme="cyberpunk"] .cp-autoload-off__title {
+  font-family: var(--font-ui);
+  font-style: normal;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+[data-theme="cyberpunk"] .cp-autoload-off__desc {
+  color: #7a6a68;
+  letter-spacing: 0.02em;
+}
+
+[data-theme="cyberpunk"] .cp-autoload-off__status {
+  color: rgba(255, 90, 90, 0.75);
+  letter-spacing: 0.18em;
 }

--- a/frontend/src/theme/theme-cyberpunk.css
+++ b/frontend/src/theme/theme-cyberpunk.css
@@ -1133,3 +1133,175 @@
   color: #00f0ff !important;
   background-color: rgba(0, 40, 50, 0.35) !important;
 }
+
+/* ── Autoload overlay — Night City (matches rest of cyberpunk shell) ── */
+
+[data-theme="cyberpunk"].cp-autoload-overlay,
+[data-theme="cyberpunk"] .cp-autoload-overlay {
+  font-family: var(--font-ui);
+  /* ps5-bg gradients apply when class is present; reinforce void base */
+  background-color: #0a0508 !important;
+}
+
+[data-theme="cyberpunk"] .cp-autoload-overlay__warn {
+  border-radius: 0;
+  clip-path: polygon(
+    0 0,
+    100% 0,
+    100% calc(100% - 10px),
+    calc(100% - 10px) 100%,
+    0 100%
+  );
+  background: rgba(252, 238, 10, 0.06);
+  border-color: rgba(252, 238, 10, 0.45);
+  color: #fcee0a;
+  letter-spacing: 0.12em;
+  box-shadow: 0 0 20px rgba(252, 238, 10, 0.08);
+}
+
+[data-theme="cyberpunk"] .cp-autoload-overlay__eyebrow {
+  letter-spacing: 0.28em;
+  color: #00f0ff;
+  text-shadow: 0 0 16px rgba(0, 240, 255, 0.4);
+  font-style: italic;
+}
+
+[data-theme="cyberpunk"] .cp-autoload-overlay__ring-track {
+  color: rgba(255, 60, 60, 0.12);
+}
+
+[data-theme="cyberpunk"] .cp-autoload-overlay__ring-fill {
+  color: #00f0ff;
+  filter: drop-shadow(0 0 8px rgba(0, 240, 255, 0.45));
+}
+
+[data-theme="cyberpunk"] .cp-autoload-overlay__ring-num {
+  font-family: var(--font-ui);
+  letter-spacing: 0.06em;
+  text-shadow:
+    -1px 0 rgba(255, 42, 109, 0.45),
+    1px 0 rgba(0, 240, 255, 0.55);
+}
+
+[data-theme="cyberpunk"] .cp-autoload-overlay__hint {
+  color: #7a6a68;
+  letter-spacing: 0.18em;
+  font-style: normal;
+}
+
+/* Done badge — angular cyan, not soft green pill */
+[data-theme="cyberpunk"] .cp-autoload-overlay__done-icon {
+  border-radius: 0;
+  padding: 1.75rem;
+  color: #0a0508;
+  background: linear-gradient(135deg, #00f0ff 0%, #00a8b3 55%, #fcee0a 100%);
+  border: 1px solid rgba(0, 240, 255, 0.8);
+  box-shadow:
+    0 0 32px rgba(0, 240, 255, 0.35),
+    0 0 48px rgba(252, 238, 10, 0.12);
+  clip-path: polygon(
+    0 0,
+    100% 0,
+    100% calc(100% - 16px),
+    calc(100% - 16px) 100%,
+    0 100%
+  );
+}
+
+[data-theme="cyberpunk"] .cp-autoload-overlay__done-title {
+  font-family: var(--font-ui);
+  font-style: italic;
+  letter-spacing: 0.12em;
+  color: #ff3c3c;
+  text-shadow:
+    -1px 0 rgba(0, 240, 255, 0.65),
+    1px 0 rgba(255, 42, 109, 0.55),
+    0 0 22px rgba(255, 60, 60, 0.4);
+}
+
+/* Payload list panel */
+[data-theme="cyberpunk"] .cp-autoload-overlay__list {
+  border-radius: 0 !important;
+  /* glass-card BR cut already applied via class; reinforce fill */
+  background: rgba(12, 4, 8, 0.82) !important;
+  gap: 0.75rem;
+}
+
+[data-theme="cyberpunk"] .cp-autoload-overlay__list-head {
+  border-radius: 0;
+  background: linear-gradient(180deg, rgba(40, 4, 8, 0.9) 0%, rgba(12, 4, 8, 0.75) 100%);
+  border-bottom: 1px solid rgba(255, 60, 60, 0.28);
+  margin-left: -0.25rem;
+  margin-right: -0.25rem;
+  padding-left: 0.75rem;
+  padding-right: 0.75rem;
+}
+
+[data-theme="cyberpunk"] .cp-autoload-overlay__list-head .label-caps {
+  color: #ff3c3c !important;
+  letter-spacing: 0.2em !important;
+  text-shadow: 0 0 12px rgba(255, 60, 60, 0.35);
+}
+
+[data-theme="cyberpunk"] .cp-autoload-overlay__count {
+  border-radius: 0.2rem;
+  background: rgba(0, 240, 255, 0.1);
+  border: 1px solid rgba(0, 240, 255, 0.35);
+  color: #00f0ff;
+  letter-spacing: 0.12em;
+}
+
+[data-theme="cyberpunk"] .cp-autoload-overlay__item {
+  border-radius: 0 !important;
+  /* nested glass-card inherits BR cut */
+  opacity: 1;
+}
+
+[data-theme="cyberpunk"] .cp-autoload-overlay__item.is-pending {
+  opacity: 0.45;
+  --cp-edge: rgba(255, 60, 60, 0.2);
+  --cp-fill: rgba(12, 4, 8, 0.5);
+}
+
+[data-theme="cyberpunk"] .cp-autoload-overlay__item.is-active {
+  --cp-edge: #00f0ff;
+  --cp-fill: rgba(0, 240, 255, 0.08);
+  transform: scale(1.02);
+  box-shadow: 0 0 24px rgba(0, 240, 255, 0.15) !important;
+}
+
+[data-theme="cyberpunk"] .cp-autoload-overlay__item.is-done {
+  --cp-edge: rgba(0, 240, 255, 0.4);
+  --cp-fill: rgba(0, 40, 45, 0.35);
+  background-color: rgba(0, 40, 45, 0.35) !important;
+  border-color: rgba(0, 240, 255, 0.4) !important;
+}
+
+[data-theme="cyberpunk"] .cp-autoload-overlay__item-icon.is-done {
+  color: #00f0ff;
+  filter: drop-shadow(0 0 6px rgba(0, 240, 255, 0.5));
+}
+
+[data-theme="cyberpunk"] .cp-autoload-overlay__item-icon.is-active {
+  color: #fcee0a;
+  filter: drop-shadow(0 0 6px rgba(252, 238, 10, 0.45));
+}
+
+[data-theme="cyberpunk"] .cp-autoload-overlay__item-icon.is-pending {
+  border-radius: 0;
+  border-color: rgba(255, 60, 60, 0.35);
+  background: transparent;
+}
+
+[data-theme="cyberpunk"] .cp-autoload-overlay__item-tag {
+  color: #00f0ff;
+  font-style: normal;
+  letter-spacing: 0.18em;
+  text-shadow: 0 0 8px rgba(0, 240, 255, 0.35);
+}
+
+[data-theme="cyberpunk"] .cp-autoload-overlay__dots span {
+  border-radius: 0;
+  background: #00f0ff;
+  box-shadow: 0 0 8px rgba(0, 240, 255, 0.5);
+}

--- a/frontend/src/theme/theme-cyberpunk.css
+++ b/frontend/src/theme/theme-cyberpunk.css
@@ -1099,3 +1099,37 @@
   color: rgba(255, 90, 90, 0.75);
   letter-spacing: 0.18em;
 }
+
+/* FLATLINED — cyberpunk intensifies the death-menu look */
+[data-theme="cyberpunk"] .cp-flatlined,
+.cp-flatlined--cyber {
+  background:
+    radial-gradient(ellipse 80% 60% at 20% 40%, rgba(120, 0, 20, 0.35) 0%, transparent 55%),
+    linear-gradient(180deg, #120308 0%, #050204 100%);
+  font-family: var(--font-ui);
+}
+
+[data-theme="cyberpunk"] .cp-flatlined__panel,
+.cp-flatlined--cyber .cp-flatlined__panel {
+  clip-path: polygon(
+    0 0,
+    100% 0,
+    100% calc(100% - 18px),
+    calc(100% - 18px) 100%,
+    0 100%
+  );
+  border-color: rgba(255, 60, 60, 0.5);
+}
+
+[data-theme="cyberpunk"] .cp-flatlined__title,
+.cp-flatlined--cyber .cp-flatlined__title {
+  font-family: var(--font-display), var(--font-ui);
+  letter-spacing: 0.12em;
+}
+
+[data-theme="cyberpunk"] .cp-flatlined__primary.cp-btn,
+.cp-flatlined--cyber .cp-flatlined__primary.cp-btn {
+  border-color: #00f0ff !important;
+  color: #00f0ff !important;
+  background-color: rgba(0, 40, 50, 0.35) !important;
+}

--- a/frontend/src/theme/theme-cyberpunk.css
+++ b/frontend/src/theme/theme-cyberpunk.css
@@ -61,6 +61,10 @@
  * - active: cyan text + thin cyan rectangular frame only
  * - no cursor chip / no heavy fill
  */
+[data-theme="cyberpunk"] .cp-sidebar__nav {
+  gap: 0.15rem !important;
+}
+
 [data-theme="cyberpunk"] .cp-sidebar .cp-nav-item {
   letter-spacing: 0.16em !important;
   border-radius: 0 !important;
@@ -71,6 +75,7 @@
   box-shadow: none !important;
   text-shadow: none !important;
   padding: 0.85rem 1.15rem !important;
+  margin-bottom: 0 !important;
   min-height: 3rem;
   gap: 0.85rem !important;
   justify-content: flex-start !important;
@@ -102,14 +107,49 @@
   opacity: 0.9;
 }
 
-/* Collapsed rail: keep square frame around icon only */
+/* Collapsed rail: square icon tiles that fully fit (no clipped borders) */
+[data-theme="cyberpunk"] .cp-sidebar--collapsed .cp-nav-item,
 [data-theme="cyberpunk"] .cp-sidebar .cp-nav-item.justify-center {
   justify-content: center !important;
-  padding: 0.75rem !important;
-  width: auto !important;
-  min-width: 3rem;
-  margin-left: auto;
-  margin-right: auto;
+  align-items: center !important;
+  padding: 0 !important;
+  width: 2.75rem !important;
+  min-width: 2.75rem !important;
+  max-width: 2.75rem !important;
+  height: 2.75rem !important;
+  min-height: 2.75rem !important;
+  margin: 0 auto !important;
+  gap: 0 !important;
+  box-sizing: border-box !important;
+  overflow: visible !important;
+}
+
+[data-theme="cyberpunk"] .cp-sidebar--collapsed .cp-nav-item svg,
+[data-theme="cyberpunk"] .cp-sidebar .cp-nav-item.justify-center svg {
+  width: 1.25rem !important;
+  height: 1.25rem !important;
+  flex-shrink: 0;
+}
+
+/* Hide label box entirely when collapsed so it can't steal width */
+[data-theme="cyberpunk"] .cp-sidebar--collapsed .cp-nav-item > span {
+  display: none !important;
+  width: 0 !important;
+  opacity: 0 !important;
+  overflow: hidden !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+[data-theme="cyberpunk"] .cp-sidebar--collapsed .cp-sidebar__toggle {
+  width: 2.75rem;
+  height: 2.75rem;
+  padding: 0;
+  border: 1px solid rgba(255, 60, 60, 0.28);
+  border-radius: 0.35rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 /* Donate uses same frame, warmer red when idle */
@@ -470,15 +510,45 @@
 
 /* Corner chips removed — they clipped headers / card top borders */
 
+/* Settings cards — cyberpunk chrome (angular, not crushed copy) */
+[data-theme="cyberpunk"] .setting-row {
+  border-radius: 0.35rem !important;
+  border-color: rgba(255, 60, 60, 0.18) !important;
+  background: rgba(18, 6, 10, 0.72) !important;
+}
+
+[data-theme="cyberpunk"] .setting-row:hover {
+  border-color: rgba(0, 240, 255, 0.35) !important;
+}
+
+[data-theme="cyberpunk"] .setting-row__title {
+  /* Mono + huge tracking made "Multiple Payload Sources" wrap word-by-word */
+  letter-spacing: 0.06em !important;
+  font-style: normal !important;
+  line-height: 1.35 !important;
+}
+
+[data-theme="cyberpunk"] .setting-row__desc {
+  color: #7a6a68 !important;
+  letter-spacing: 0.01em !important;
+}
+
+[data-theme="cyberpunk"] .setting-row__icon {
+  border-radius: 0.35rem !important;
+  border: 1px solid rgba(255, 60, 60, 0.2);
+  color: rgba(255, 90, 90, 0.65) !important;
+}
+
 /*
  * OFF | ON segmented toggle (settings UI reference)
  * Angular ends, dim OFF side, solid cyan ON side when selected.
+ * Slightly narrower so it coexists with long titles in half-width cards.
  */
 [data-theme="cyberpunk"] .cp-toggle {
   display: inline-flex;
   align-items: stretch;
-  width: 9.5rem;
-  height: 2.25rem;
+  width: 8.25rem;
+  height: 2.15rem;
   padding: 0;
   border: 1px solid rgba(255, 60, 60, 0.35);
   background: rgba(8, 2, 6, 0.9);
@@ -489,8 +559,8 @@
 
 @media (min-width: 768px) {
   [data-theme="cyberpunk"] .cp-toggle {
-    width: 11rem;
-    height: 2.6rem;
+    width: 9.5rem;
+    height: 2.45rem;
   }
 }
 
@@ -556,4 +626,317 @@
 [data-theme="cyberpunk"] .cp-toggle.is-on .cp-toggle__seg--off {
   color: rgba(255, 90, 90, 0.4);
   background: rgba(40, 8, 14, 0.9);
+}
+
+
+/* ═══════════════════════════════════════════════════════════════════
+ * CP2077 menu action buttons (Install / Update / Upload / etc.)
+ * Match in-game CRAFTING / INVENTORY / MAP / DATABASE bar tiles.
+ * ═══════════════════════════════════════════════════════════════════ */
+
+[data-theme="cyberpunk"] .cp-btn {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.65rem;
+  min-height: 2.75rem;
+  padding: 0.7rem 1.35rem;
+  border: 1px solid rgba(255, 60, 60, 0.38);
+  border-radius: 0;
+  background:
+    linear-gradient(180deg, rgba(50, 10, 16, 0.72) 0%, rgba(18, 6, 10, 0.85) 100%);
+  color: rgba(0, 240, 255, 0.82);
+  font-family: var(--font-ui);
+  font-weight: 800;
+  font-size: 0.78rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  line-height: 1.1;
+  cursor: pointer;
+  outline: none;
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 0, 0, 0.4),
+    0 0 0 0 transparent;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease,
+    background 0.15s ease,
+    box-shadow 0.15s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+[data-theme="cyberpunk"] .cp-btn:hover:not(:disabled),
+[data-theme="cyberpunk"] .cp-btn:focus-visible:not(:disabled) {
+  color: #00f0ff;
+  border-color: #00f0ff;
+  background:
+    linear-gradient(90deg, rgba(80, 12, 20, 0.75) 0%, rgba(0, 50, 60, 0.4) 100%);
+  box-shadow:
+    0 0 20px rgba(0, 240, 255, 0.14),
+    inset 0 0 0 1px rgba(0, 240, 255, 0.18);
+}
+
+[data-theme="cyberpunk"] .cp-btn:active:not(:disabled) {
+  transform: translateY(1px);
+}
+
+[data-theme="cyberpunk"] .cp-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+  filter: grayscale(0.3);
+}
+
+[data-theme="cyberpunk"] .cp-btn__icon {
+  flex-shrink: 0;
+  color: currentColor;
+}
+
+[data-theme="cyberpunk"] .cp-btn__label {
+  white-space: nowrap;
+}
+
+/* Primary — selected MAP-style cyan frame */
+[data-theme="cyberpunk"] .cp-btn--primary {
+  border-color: rgba(0, 240, 255, 0.55);
+  color: #00f0ff;
+  background:
+    linear-gradient(90deg, rgba(70, 8, 16, 0.8) 0%, rgba(0, 45, 55, 0.45) 55%, rgba(20, 8, 14, 0.8) 100%);
+  box-shadow:
+    inset 0 0 24px rgba(0, 240, 255, 0.05),
+    0 0 12px rgba(0, 240, 255, 0.08);
+}
+
+[data-theme="cyberpunk"] .cp-btn--primary:hover:not(:disabled),
+[data-theme="cyberpunk"] .cp-btn--primary:focus-visible:not(:disabled) {
+  border-color: #00f0ff;
+  color: #00f0ff;
+  background:
+    linear-gradient(90deg, rgba(90, 10, 18, 0.85) 0%, rgba(0, 70, 80, 0.5) 100%);
+  box-shadow:
+    0 0 24px rgba(0, 240, 255, 0.22),
+    inset 0 0 0 1px rgba(0, 240, 255, 0.25);
+}
+
+/* Secondary / Cancel — dim red frame like idle CRAFTING */
+[data-theme="cyberpunk"] .cp-btn--secondary {
+  border-color: rgba(255, 60, 60, 0.32);
+  color: rgba(255, 120, 120, 0.8);
+  background: rgba(24, 6, 10, 0.7);
+}
+
+[data-theme="cyberpunk"] .cp-btn--secondary:hover:not(:disabled) {
+  border-color: rgba(0, 240, 255, 0.55);
+  color: #00f0ff;
+  background: rgba(0, 40, 48, 0.35);
+}
+
+/* Danger — Kill / Delete / Abort */
+[data-theme="cyberpunk"] .cp-btn--danger {
+  border-color: rgba(255, 60, 60, 0.65);
+  color: #ff6b6b;
+  background: linear-gradient(90deg, rgba(70, 8, 12, 0.85) 0%, rgba(40, 6, 10, 0.75) 100%);
+}
+
+[data-theme="cyberpunk"] .cp-btn--danger:hover:not(:disabled) {
+  border-color: #ff3c3c;
+  color: #fff;
+  background: rgba(255, 40, 50, 0.28);
+  box-shadow: 0 0 20px rgba(255, 60, 60, 0.25);
+}
+
+/* Soft danger — icon row delete */
+[data-theme="cyberpunk"] .cp-btn--dangerSoft {
+  border-color: rgba(255, 60, 60, 0.28);
+  color: #ff6b6b;
+  background: rgba(40, 6, 10, 0.45);
+  min-height: 2.4rem;
+  padding: 0.5rem 0.75rem;
+}
+
+[data-theme="cyberpunk"] .cp-btn--dangerSoft:hover:not(:disabled) {
+  border-color: #ff3c3c;
+  color: #fff;
+  background: rgba(255, 50, 60, 0.25);
+}
+
+/* Success — Update */
+[data-theme="cyberpunk"] .cp-btn--success {
+  border-color: rgba(0, 240, 255, 0.45);
+  color: #7dffc8;
+  background:
+    linear-gradient(90deg, rgba(0, 40, 30, 0.55) 0%, rgba(0, 50, 55, 0.4) 100%);
+}
+
+[data-theme="cyberpunk"] .cp-btn--success:hover:not(:disabled) {
+  border-color: #00f0ff;
+  color: #00f0ff;
+  box-shadow: 0 0 18px rgba(0, 240, 255, 0.18);
+}
+
+/* Ghost — dashed idle / secondary actions */
+[data-theme="cyberpunk"] .cp-btn--ghost {
+  border-style: solid;
+  border-color: rgba(255, 60, 60, 0.22);
+  color: rgba(255, 100, 100, 0.7);
+  background: transparent;
+}
+
+[data-theme="cyberpunk"] .cp-btn--ghost:hover:not(:disabled) {
+  border-color: rgba(0, 240, 255, 0.5);
+  color: #00f0ff;
+  background: rgba(0, 240, 255, 0.05);
+}
+
+/* Sizes */
+[data-theme="cyberpunk"] .cp-btn--sm {
+  min-height: 2.15rem;
+  padding: 0.45rem 0.9rem;
+  font-size: 0.68rem;
+  letter-spacing: 0.14em;
+  gap: 0.45rem;
+}
+
+[data-theme="cyberpunk"] .cp-btn--lg {
+  min-height: 3.5rem;
+  padding: 1rem 1.75rem;
+  font-size: 0.95rem;
+  letter-spacing: 0.18em;
+  gap: 0.85rem;
+}
+
+[data-theme="cyberpunk"] .cp-btn--block {
+  width: 100%;
+}
+
+/* Icon-only square (trash, chevrons in rows) */
+[data-theme="cyberpunk"] .cp-btn--icon {
+  min-width: 2.5rem;
+  min-height: 2.5rem;
+  padding: 0.5rem;
+  gap: 0;
+}
+
+/* Full-width menu bar tiles (autoload enable, overlay actions) */
+[data-theme="cyberpunk"] .cp-btn--bar {
+  width: 100%;
+  min-height: 3.75rem;
+  justify-content: flex-start;
+  padding-left: 1.5rem;
+  padding-right: 1.5rem;
+  font-size: 1rem;
+  letter-spacing: 0.2em;
+}
+
+/* Bar rows with trailing arrow (Autoload available payloads) */
+[data-theme="cyberpunk"] .cp-btn--with-end,
+[data-theme="cyberpunk"] .cp-btn--bar.cp-btn--with-end {
+  justify-content: space-between;
+  text-align: left;
+}
+
+[data-theme="cyberpunk"] .cp-btn__end {
+  margin-left: auto;
+  opacity: 0.55;
+  transition: opacity 0.15s ease, transform 0.15s ease, color 0.15s ease;
+}
+
+[data-theme="cyberpunk"] .cp-btn:hover:not(:disabled) .cp-btn__end,
+[data-theme="cyberpunk"] .cp-btn:focus-visible:not(:disabled) .cp-btn__end {
+  opacity: 1;
+  color: #00f0ff;
+  transform: translateX(4px);
+}
+
+[data-theme="cyberpunk"] .cp-btn__body {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.15rem;
+  min-width: 0;
+  white-space: normal;
+}
+
+/* Selected chip (Autoload Delay 3s/5s/10s) */
+[data-theme="cyberpunk"] .cp-btn--selected,
+[data-theme="cyberpunk"] .cp-btn.is-selected {
+  border-color: #00f0ff !important;
+  color: #00f0ff !important;
+  background:
+    linear-gradient(90deg, rgba(70, 8, 16, 0.85) 0%, rgba(0, 55, 65, 0.5) 100%) !important;
+  box-shadow:
+    0 0 22px rgba(0, 240, 255, 0.2),
+    inset 0 0 0 1px rgba(0, 240, 255, 0.25) !important;
+}
+
+[data-theme="cyberpunk"] .cp-delay-card {
+  border-radius: 0.35rem !important;
+  border-color: rgba(255, 60, 60, 0.18) !important;
+  background: rgba(18, 6, 10, 0.72) !important;
+}
+
+[data-theme="cyberpunk"] .cp-delay-card__value {
+  color: #00f0ff;
+  text-shadow: 0 0 14px rgba(0, 240, 255, 0.35);
+  font-family: var(--font-ui);
+  font-style: normal;
+  letter-spacing: 0.08em;
+}
+
+[data-theme="cyberpunk"] .cp-btn--payload-row {
+  min-height: 4rem;
+  padding-top: 1rem;
+  padding-bottom: 1rem;
+  align-items: center;
+}
+
+/* Log overlay — Night City terminal */
+[data-theme="cyberpunk"] .cp-log-overlay {
+  background: #0a0508;
+}
+
+[data-theme="cyberpunk"] .cp-log-overlay__header {
+  border-bottom-color: rgba(255, 60, 60, 0.35);
+  background: linear-gradient(180deg, rgba(40, 4, 8, 0.96) 0%, rgba(12, 4, 8, 0.94) 100%);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.45);
+}
+
+[data-theme="cyberpunk"] .cp-log-overlay__title h3 {
+  font-family: var(--font-ui);
+  font-style: normal;
+  letter-spacing: 0.18em;
+  color: #ff3c3c;
+  text-shadow: 0 0 16px rgba(255, 60, 60, 0.4);
+}
+
+[data-theme="cyberpunk"] .cp-log-viewer {
+  background:
+    linear-gradient(180deg, rgba(12, 4, 8, 0.5) 0%, rgba(6, 2, 6, 0.85) 100%);
+}
+
+[data-theme="cyberpunk"] .cp-log-viewer__scroll {
+  font-family: var(--font-ui);
+  letter-spacing: 0.02em;
+}
+
+[data-theme="cyberpunk"] .cp-log-line:hover {
+  background: rgba(0, 240, 255, 0.04);
+  border-left-color: #00f0ff;
+}
+
+[data-theme="cyberpunk"] .cp-log-line__num {
+  color: rgba(255, 80, 80, 0.45);
+}
+
+[data-theme="cyberpunk"] .cp-log-line__prompt {
+  color: #00f0ff;
+  text-shadow: 0 0 8px rgba(0, 240, 255, 0.35);
+}
+
+[data-theme="cyberpunk"] .cp-log-line__text {
+  color: #e8e4e0;
+}
+
+[data-theme="cyberpunk"] .cp-log-viewer__empty {
+  color: #7a6a68;
 }

--- a/frontend/src/theme/theme-shared.css
+++ b/frontend/src/theme/theme-shared.css
@@ -885,3 +885,242 @@ button:focus {
   color: var(--color-ps-blue);
   opacity: 0.85;
 }
+
+/* ── FLATLINED offline / death screen ───────────────────────────── */
+.cp-flatlined {
+  position: relative;
+  min-height: 100%;
+  height: 100%;
+  min-height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  padding: 2rem 1.5rem;
+  overflow: hidden;
+  background: #0a0508;
+  color: #e8e4e0;
+  box-sizing: border-box;
+}
+
+.cp-flatlined__rain {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 0;
+}
+
+.cp-flatlined__rain-col {
+  position: absolute;
+  top: -30%;
+  margin: 0;
+  font-family: ui-monospace, Consolas, monospace;
+  font-size: 11px;
+  line-height: 1.45;
+  color: rgba(255, 60, 60, 0.55);
+  white-space: pre;
+  animation: cp-flat-fall linear infinite;
+}
+
+@keyframes cp-flat-fall {
+  0% { transform: translateY(0); }
+  100% { transform: translateY(140%); }
+}
+
+.cp-flatlined__scan {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  opacity: 0.35;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0, 0, 0, 0.18) 2px,
+    rgba(0, 0, 0, 0.18) 4px
+  );
+}
+
+.cp-flatlined__vignette {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1;
+  background:
+    radial-gradient(ellipse 70% 70% at 30% 45%, transparent 20%, rgba(0, 0, 0, 0.65) 100%),
+    linear-gradient(90deg, rgba(80, 0, 10, 0.45) 0%, transparent 45%);
+}
+
+.cp-flatlined__top {
+  position: absolute;
+  top: 1.25rem;
+  left: 1.25rem;
+  right: 1.25rem;
+  z-index: 3;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem;
+  pointer-events: none;
+}
+
+.cp-flatlined__chip {
+  font-family: ui-monospace, Consolas, monospace;
+  font-size: 0.65rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: rgba(255, 90, 90, 0.75);
+  border: 1px solid rgba(255, 60, 60, 0.35);
+  padding: 0.4rem 0.75rem;
+  background: rgba(20, 4, 8, 0.7);
+}
+
+.cp-flatlined__chip--warn {
+  color: #ff6b6b;
+  border-color: rgba(255, 60, 60, 0.65);
+  box-shadow: 0 0 12px rgba(255, 40, 40, 0.2);
+}
+
+.cp-flatlined__panel {
+  position: relative;
+  z-index: 2;
+  width: 100%;
+  max-width: 28rem;
+  margin-left: clamp(0.5rem, 6vw, 4rem);
+  padding: 2rem 1.75rem 1.5rem;
+  background: linear-gradient(180deg, rgba(40, 6, 10, 0.82) 0%, rgba(10, 3, 6, 0.92) 100%);
+  border: 1px solid rgba(255, 60, 60, 0.4);
+  border-radius: 0.25rem;
+  box-shadow:
+    0 0 60px rgba(120, 0, 20, 0.35),
+    inset 0 0 40px rgba(0, 0, 0, 0.35);
+  box-sizing: border-box;
+}
+
+.cp-flatlined__brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.cp-flatlined__skull {
+  width: 3.5rem;
+  height: 3.5rem;
+  color: #ff3c3c;
+  flex-shrink: 0;
+  filter: drop-shadow(0 0 12px rgba(255, 40, 40, 0.55));
+}
+
+.cp-flatlined__title {
+  margin: 0;
+  font-size: clamp(2.25rem, 6vw, 3.25rem);
+  font-weight: 900;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #ff3c3c;
+  line-height: 0.95;
+  text-shadow:
+    0 0 20px rgba(255, 40, 40, 0.65),
+    0 0 40px rgba(255, 0, 40, 0.35);
+}
+
+.cp-flatlined__deck {
+  margin: 0.35rem 0 0;
+  font-family: ui-monospace, Consolas, monospace;
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  color: rgba(255, 100, 100, 0.55);
+}
+
+.cp-flatlined__msg {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: #e8e4e0;
+  letter-spacing: 0.02em;
+}
+
+.cp-flatlined__detail {
+  margin: 0 0 1.75rem;
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: rgba(255, 160, 160, 0.55);
+}
+
+.cp-flatlined__detail strong {
+  color: #00f0ff;
+  font-weight: 800;
+}
+
+.cp-flatlined__menu {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  margin-bottom: 1.5rem;
+}
+
+.cp-flatlined__menu-item {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 0.85rem 1.15rem;
+  border: 1px solid transparent;
+  background: transparent;
+  color: rgba(255, 100, 100, 0.75);
+  font-family: inherit;
+  font-size: 0.85rem;
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: color 0.15s ease, border-color 0.15s ease, background 0.15s ease;
+}
+
+.cp-flatlined__menu-item:hover {
+  color: #00f0ff;
+  border-color: rgba(0, 240, 255, 0.45);
+  background: rgba(0, 240, 255, 0.04);
+}
+
+.cp-flatlined__foot {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-family: ui-monospace, Consolas, monospace;
+  font-size: 0.65rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 80, 80, 0.55);
+  border-top: 1px solid rgba(255, 60, 60, 0.2);
+  padding-top: 0.85rem;
+}
+
+/* Embedded FLATLINED (inside a view, not full-page takeover) */
+.cp-flatlined--embedded {
+  min-height: 22rem;
+  height: auto;
+  min-height: min(70vh, 32rem);
+  border: 1px solid rgba(255, 60, 60, 0.25);
+  border-radius: 0.25rem;
+  padding: 1.25rem 1rem 1.5rem;
+}
+
+.cp-flatlined--embedded .cp-flatlined__top {
+  position: relative;
+  top: 0;
+  left: 0;
+  right: 0;
+  margin-bottom: 1rem;
+}
+
+.cp-flatlined--embedded .cp-flatlined__panel {
+  margin-left: 0;
+  max-width: 32rem;
+}
+
+.cp-flatlined--embedded .cp-flatlined__rain-col {
+  font-size: 10px;
+}

--- a/frontend/src/theme/theme-shared.css
+++ b/frontend/src/theme/theme-shared.css
@@ -1,0 +1,384 @@
+/**
+ * Shared layout shell only — NO theme-specific colors or chrome.
+ * Visual look lives in theme-classic.css / theme-cyberpunk.css.
+ */
+
+:root {
+  color-scheme: dark;
+  /* Fallback tokens before JS runs (cyberpunk is app default) */
+  --color-ps-blue: #00f0ff;
+  --color-ps-blue-glow: rgba(0, 240, 255, 0.45);
+  --color-ps-yellow: #fcee0a;
+  --color-ps-red: #ff3c3c;
+  --color-ps-black: #0a0508;
+  --color-ps-surface: rgba(12, 4, 8, 0.92);
+  --color-ps-card: rgba(18, 6, 10, 0.82);
+  --color-ps-border: rgba(255, 60, 60, 0.28);
+  --color-nav-idle: rgba(255, 90, 90, 0.75);
+  --color-nav-active: #00f0ff;
+  --color-nav-active-bg: rgba(0, 240, 255, 0.08);
+  --color-nav-active-border: rgba(0, 240, 255, 0.75);
+  --color-nav-hover: #ff8a8a;
+  --color-nav-hover-bg: rgba(255, 60, 60, 0.06);
+  --color-title-accent: #ff3c3c;
+  --color-title-glow: rgba(255, 60, 60, 0.45);
+  --color-hud: rgba(255, 80, 80, 0.55);
+  --color-text: #e8e4e0;
+  --color-muted: #7a6a68;
+  --color-scrollbar: rgba(255, 60, 60, 0.35);
+  --color-card-hover-bg: rgba(20, 10, 16, 0.95);
+  --color-card-hover-border: rgba(0, 240, 255, 0.45);
+  --color-card-hover-shadow: 0 0 24px rgba(0, 240, 255, 0.12);
+  --color-brand: #ff3c3c;
+  --color-brand-glow: rgba(255, 60, 60, 0.55);
+  --color-brand-icon-bg: transparent;
+  --color-brand-icon-fg: #ff3c3c;
+  --color-brand-icon-border: rgba(255, 60, 60, 0.5);
+  --color-brand-icon-shadow: 0 0 16px rgba(255, 60, 60, 0.25);
+  --font-ui: "Share Tech Mono", Consolas, "Courier New", monospace;
+  --font-display: "Share Tech Mono", Consolas, monospace;
+  --font-inter: var(--font-ui);
+  --radius-ps-xl: 0.25rem;
+  --radius-ps-2xl: 0.35rem;
+  --radius-ps-3xl: 0.5rem;
+  --radius-nav: 2px;
+  --letter-spacing-body: 0.02em;
+  --letter-spacing-heading: 0.04em;
+  --text-transform-heading: uppercase;
+  --theme-atmosphere: 1;
+}
+
+html, body, #root {
+  height: 100%;
+  height: -webkit-fill-available;
+  max-height: 100%;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background-color: var(--color-ps-black);
+  color: var(--color-text);
+  font-family: var(--font-ui);
+  font-size: 16px;
+  letter-spacing: var(--letter-spacing-body);
+  -webkit-font-smoothing: antialiased;
+  overflow: hidden;
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
+@media (min-width: 768px) {
+  body {
+    height: 100vh;
+    max-height: 100vh;
+    font-size: 20px;
+  }
+}
+
+/* Layout shell */
+.app-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  max-height: 100%;
+  min-height: 0;
+  overflow: hidden;
+  position: relative;
+}
+
+@supports (height: 100dvh) {
+  .app-shell {
+    height: 100dvh;
+    max-height: 100dvh;
+  }
+}
+
+.app-body {
+  display: flex;
+  flex: 1 1 0%;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  align-items: stretch;
+}
+
+.app-main-wrap {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0%;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  position: relative;
+}
+
+.app-main {
+  flex: 1 1 0%;
+  min-height: 0;
+  width: 100%;
+  max-width: 1800px;
+  margin-left: auto;
+  margin-right: auto;
+  overflow-x: hidden;
+  overflow-y: auto !important;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+}
+
+.ps5-bg {
+  background-color: var(--color-ps-black);
+  position: relative;
+}
+
+.ps5-bg > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* Structure-only sidebar */
+.cp-sidebar {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  align-self: stretch;
+  height: 100%;
+  min-height: 0;
+}
+
+.cp-sidebar__inner {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0%;
+  min-height: 0;
+  padding: 1.25rem 1.5rem;
+  box-sizing: border-box;
+}
+
+.cp-sidebar__brand {
+  display: flex;
+  align-items: center;
+  height: 2.5rem;
+  margin-bottom: 1.75rem;
+  flex-shrink: 0;
+}
+
+.cp-sidebar__nav {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: stretch;
+  gap: 0.15rem;
+  -webkit-overflow-scrolling: touch;
+}
+
+.cp-sidebar__nav > * {
+  flex: 0 0 auto !important;
+}
+
+.cp-sidebar__foot {
+  flex-shrink: 0;
+  margin-top: auto;
+  padding-top: 1.25rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* Token-driven shared components (both themes set these vars) */
+.glass-panel {
+  background: var(--color-ps-surface);
+  border-right: 1px solid var(--color-ps-border);
+}
+
+.glass-card {
+  background: var(--color-ps-card);
+  border: 1px solid var(--color-ps-border);
+  border-radius: var(--radius-ps-xl);
+  transition: all 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.glass-card:hover,
+.glass-card:focus {
+  background: var(--color-card-hover-bg);
+  border-color: var(--color-card-hover-border);
+  box-shadow: var(--color-card-hover-shadow);
+  /* no translateY — lifts clip card top borders inside overflow scrollports */
+  outline: none;
+}
+
+.cp-brand {
+  font-weight: 800;
+  color: var(--color-brand);
+  text-shadow: 0 0 18px var(--color-brand-glow);
+  letter-spacing: var(--letter-spacing-heading);
+  text-transform: var(--text-transform-heading);
+}
+
+.cp-brand-icon {
+  background: var(--color-brand-icon-bg);
+  color: var(--color-brand-icon-fg);
+  border: 1px solid var(--color-brand-icon-border);
+  box-shadow: var(--color-brand-icon-shadow);
+  border-radius: var(--radius-ps-xl);
+}
+
+.cp-nav-item {
+  color: var(--color-nav-idle) !important;
+  background: transparent !important;
+  border: 1px solid transparent !important;
+  border-radius: var(--radius-nav) !important;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-weight: 700;
+}
+
+.cp-nav-item:hover {
+  color: var(--color-nav-hover) !important;
+  background: var(--color-nav-hover-bg) !important;
+}
+
+.cp-nav-item.is-active {
+  color: var(--color-nav-active) !important;
+  background: var(--color-nav-active-bg) !important;
+  border-color: var(--color-nav-active-border) !important;
+}
+
+.cp-title-accent {
+  color: var(--color-title-accent);
+  text-shadow: 0 0 14px var(--color-title-glow);
+}
+
+.cp-progress-fill {
+  background: var(--color-ps-blue);
+}
+
+.label-caps {
+  text-transform: uppercase;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+h1, h2, h3, h4 {
+  font-weight: 800;
+  letter-spacing: var(--letter-spacing-heading);
+  text-transform: var(--text-transform-heading);
+}
+
+button:focus {
+  outline: none;
+}
+
+.neon-text {
+  text-shadow: 0 0 10px var(--color-ps-blue-glow);
+  color: var(--color-ps-blue);
+}
+
+.neon-border {
+  box-shadow: 0 0 15px var(--color-ps-blue-glow);
+  border-color: var(--color-ps-blue);
+}
+
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--color-scrollbar);
+  border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: var(--color-ps-blue);
+}
+
+.ps5-robust-spinner {
+  width: 6rem;
+  height: 6rem;
+  border: 8px solid rgba(255, 255, 255, 0.08);
+  border-left-color: var(--color-ps-blue);
+  border-radius: 50%;
+  animation: ps5-native-spin 1s linear infinite;
+  -webkit-animation: ps5-native-spin 1s linear infinite;
+  will-change: transform;
+}
+
+@keyframes ps5-native-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+@-webkit-keyframes ps5-native-spin {
+  from { -webkit-transform: rotate(0deg); }
+  to { -webkit-transform: rotate(360deg); }
+}
+
+.animate-fade-in { }
+.animate-spin {
+  transform-origin: center;
+  -webkit-transform-origin: center;
+  will-change: transform;
+}
+
+/* Theme picker (token-driven) */
+.cp-theme-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.cp-theme-card {
+  text-align: left;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid var(--color-ps-border);
+  background: var(--color-ps-card);
+  color: inherit;
+  cursor: pointer;
+  transition: border-color 0.2s, box-shadow 0.2s, background 0.2s;
+  font-family: var(--font-ui);
+  border-radius: var(--radius-ps-xl);
+}
+
+.cp-theme-card:hover {
+  border-color: var(--color-ps-blue);
+}
+
+.cp-theme-card.is-active {
+  border-color: var(--color-ps-blue);
+  box-shadow: 0 0 20px var(--color-ps-blue-glow);
+  background: var(--color-nav-active-bg);
+}
+
+.cp-theme-card__swatches {
+  display: flex;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.cp-theme-card__swatch {
+  width: 28px;
+  height: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.cp-theme-card__name {
+  font-weight: 800;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  font-size: 14px;
+  margin-bottom: 6px;
+}
+
+.cp-theme-card__desc {
+  font-size: 12px;
+  color: var(--color-muted);
+  line-height: 1.4;
+}

--- a/frontend/src/theme/theme-shared.css
+++ b/frontend/src/theme/theme-shared.css
@@ -405,18 +405,21 @@ button:focus {
  */
 .setting-row {
   display: grid;
-  grid-template-columns: auto minmax(12rem, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   grid-template-areas: "icon copy control";
   column-gap: 1rem;
   row-gap: 0.75rem;
   align-items: center;
   height: 100%;
+  min-width: 0; /* allow grid cell to shrink — long i18n must not widen the column */
+  max-width: 100%;
   padding: 1.25rem 1.25rem;
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 1.5rem;
   transition: border-color 0.2s ease, background 0.2s ease;
   box-sizing: border-box;
+  overflow: hidden; /* keep controls inside the card */
 }
 
 @media (min-width: 768px) {
@@ -489,7 +492,7 @@ button:focus {
   max-width: 36rem;
 }
 
-/* Control column — reserved width, never squeezes the copy column */
+/* Control column — fixed-ish width for toggles; never grow from long labels */
 .setting-row__control {
   grid-area: control;
   flex-shrink: 0;
@@ -497,7 +500,8 @@ button:focus {
   align-items: center;
   justify-content: flex-end;
   align-self: center;
-  min-width: max-content;
+  min-width: 0;
+  max-width: 100%;
 }
 
 /* Vertical variant (language picker): control under copy, full width */
@@ -512,11 +516,71 @@ button:focus {
 .setting-row--vertical .setting-row__control {
   justify-content: stretch;
   width: 100%;
+  max-width: 100%;
+  min-width: 0;
   padding-top: 0.25rem;
 }
 
 .setting-row--vertical .setting-row__control > * {
   width: 100%;
+  max-width: 100%;
+  min-width: 0;
+}
+
+/* Language <select> face — cap width, truncate long locale names */
+.cp-lang-select {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 0.75rem;
+  background: rgba(0, 0, 0, 0.5);
+  color: #fff;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  overflow: hidden;
+  transition: background 0.15s ease;
+}
+
+.cp-lang-select:hover {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.cp-lang-select__label {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cp-lang-select__chevron {
+  flex-shrink: 0;
+  width: 1.25rem;
+  height: 1.25rem;
+  color: #71717a;
+  transform: rotate(90deg);
+}
+
+.cp-lang-select__native {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  max-width: 100%;
+  height: 100%;
+  margin: 0;
+  opacity: 0;
+  cursor: pointer;
+  /* prevent native control from imposing option-list min-width on the layout */
+  min-width: 0;
+  font-size: 16px; /* avoid iOS zoom; does not expand our face */
 }
 
 /* Narrow cards (two-up grid): stack control under text so titles keep room */

--- a/frontend/src/theme/theme-shared.css
+++ b/frontend/src/theme/theme-shared.css
@@ -779,6 +779,260 @@ button:focus {
   filter: drop-shadow(0 8px 24px rgba(0, 0, 0, 0.55));
 }
 
+/* ── Autoload runtime overlay (countdown / execute / done) ── */
+
+.cp-autoload-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  overflow-y: auto;
+  background: #08080a;
+}
+
+@media (min-width: 768px) {
+  .cp-autoload-overlay {
+    padding: 3rem;
+  }
+}
+
+.cp-autoload-overlay__inner {
+  position: relative;
+}
+
+.cp-autoload-overlay__warn {
+  width: 100%;
+  padding: 1rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  color: #f59e0b;
+  background: rgba(245, 158, 11, 0.1);
+  border: 1px solid rgba(245, 158, 11, 0.5);
+  border-radius: 1rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.75rem;
+}
+
+.cp-autoload-overlay__status {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+  text-align: center;
+}
+
+.cp-autoload-overlay__eyebrow {
+  color: var(--color-ps-blue);
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  font-size: 1.25rem;
+}
+
+.cp-autoload-overlay__ring {
+  position: relative;
+  height: 14rem;
+  width: 14rem;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cp-autoload-overlay__ring-track {
+  color: rgba(255, 255, 255, 0.05);
+}
+
+.cp-autoload-overlay__ring-fill {
+  color: var(--color-ps-blue);
+}
+
+.cp-autoload-overlay__ring-num {
+  font-size: 4.5rem;
+  font-weight: 700;
+  color: #fff;
+  font-variant-numeric: tabular-nums;
+  line-height: 1;
+}
+
+.cp-autoload-overlay__ring-num--pct {
+  font-size: 3.75rem;
+  font-weight: 900;
+}
+
+.cp-autoload-overlay__hint {
+  color: #71717a;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.875rem;
+}
+
+.cp-autoload-overlay__done {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2rem;
+}
+
+.cp-autoload-overlay__done-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5rem;
+  border-radius: 9999px;
+  background: #10b981;
+  color: #fff;
+}
+
+.cp-autoload-overlay__done-title {
+  font-size: 3rem;
+  font-weight: 900;
+  color: #fff;
+  text-transform: uppercase;
+  letter-spacing: -0.025em;
+  line-height: 1.05;
+}
+
+@media (min-width: 768px) {
+  .cp-autoload-overlay__done-title {
+    font-size: 3.75rem;
+  }
+}
+
+.cp-autoload-overlay__dots {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.cp-autoload-overlay__dots span {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: var(--color-ps-blue);
+  animation: cp-autoload-bounce 1s ease-in-out infinite;
+}
+
+.cp-autoload-overlay__dots span:nth-child(2) {
+  animation-delay: 0.2s;
+}
+
+.cp-autoload-overlay__dots span:nth-child(3) {
+  animation-delay: 0.4s;
+}
+
+@keyframes cp-autoload-bounce {
+  0%,
+  100% {
+    transform: translateY(0);
+    opacity: 0.55;
+  }
+  50% {
+    transform: translateY(-0.4rem);
+    opacity: 1;
+  }
+}
+
+.cp-autoload-overlay__list {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  overflow-y: auto;
+  padding: 2rem;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 2.5rem;
+}
+
+.cp-autoload-overlay__list-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5rem;
+  padding: 1rem 0.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 1rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.cp-autoload-overlay__list-head .label-caps {
+  color: #fff;
+}
+
+.cp-autoload-overlay__count {
+  background: rgba(255, 255, 255, 0.1);
+  padding: 0.25rem 1rem;
+  border-radius: 9999px;
+  color: #d4d4d8;
+  font-weight: 900;
+  font-size: 0.75rem;
+}
+
+.cp-autoload-overlay__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  background: rgba(255, 255, 255, 0.05);
+  transition: all 0.4s ease;
+}
+
+.cp-autoload-overlay__item.is-active {
+  background: color-mix(in srgb, var(--color-ps-blue) 20%, transparent);
+  border-color: var(--color-ps-blue);
+  transform: scale(1.02);
+  z-index: 10;
+  opacity: 1;
+}
+
+.cp-autoload-overlay__item.is-done {
+  background: rgba(16, 185, 129, 0.05);
+  border-color: rgba(16, 185, 129, 0.2);
+  opacity: 1;
+}
+
+.cp-autoload-overlay__item.is-pending {
+  opacity: 0.4;
+}
+
+.cp-autoload-overlay__item-icon.is-done {
+  color: #10b981;
+}
+
+.cp-autoload-overlay__item-icon.is-active {
+  color: var(--color-ps-blue);
+}
+
+.cp-autoload-overlay__item-icon.is-pending {
+  border-radius: 9999px;
+  border: 2px solid rgba(255, 255, 255, 0.1);
+}
+
+.cp-autoload-overlay__item-tag {
+  color: #10b981;
+  font-size: 10px;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-style: italic;
+  flex-shrink: 0;
+}
+
 /* Autoload disabled empty state (replaces old circular refresh panel) */
 .cp-autoload-off {
   flex: 1 1 0%;

--- a/frontend/src/theme/theme-shared.css
+++ b/frontend/src/theme/theme-shared.css
@@ -778,3 +778,110 @@ button:focus {
   pointer-events: auto;
   filter: drop-shadow(0 8px 24px rgba(0, 0, 0, 0.55));
 }
+
+/* Autoload disabled empty state (replaces old circular refresh panel) */
+.cp-autoload-off {
+  flex: 1 1 0%;
+  min-height: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.cp-autoload-off__panel {
+  width: 100%;
+  max-width: 40rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.75rem;
+  padding: 2.5rem 2rem;
+  text-align: center;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 1.5rem;
+  box-sizing: border-box;
+}
+
+.cp-autoload-off__icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 5rem;
+  height: 5rem;
+  color: var(--color-ps-blue);
+  background: rgba(0, 149, 255, 0.1);
+  border: 1px solid rgba(0, 149, 255, 0.25);
+  border-radius: 1.25rem;
+}
+
+.cp-autoload-off__copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-width: 32rem;
+}
+
+.cp-autoload-off__title {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 900;
+  color: #fff;
+  letter-spacing: -0.02em;
+  line-height: 1.15;
+}
+
+@media (min-width: 768px) {
+  .cp-autoload-off__title {
+    font-size: 2.75rem;
+  }
+  .cp-autoload-off__icon {
+    width: 5.5rem;
+    height: 5.5rem;
+  }
+}
+
+.cp-autoload-off__desc {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.55;
+  color: #a1a1aa;
+}
+
+.cp-autoload-off__status {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: #71717a;
+}
+
+.cp-autoload-off__actions {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  width: 100%;
+  max-width: 22rem;
+}
+
+.cp-autoload-off__toggle-row {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+}
+
+.cp-autoload-off__save {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-ps-blue);
+  opacity: 0.85;
+}

--- a/frontend/src/theme/theme-shared.css
+++ b/frontend/src/theme/theme-shared.css
@@ -143,6 +143,7 @@ body {
   align-self: stretch;
   height: 100%;
   min-height: 0;
+  overflow: hidden; /* contain children; collapsed rail sizes carefully */
 }
 
 .cp-sidebar__inner {
@@ -150,40 +151,85 @@ body {
   flex-direction: column;
   flex: 1 1 0%;
   min-height: 0;
-  padding: 1.25rem 1.5rem;
+  min-width: 0;
+  padding: 1.25rem 1.25rem;
   box-sizing: border-box;
+}
+
+/* Collapsed rail: tight but enough room for icon + 1px border frame */
+.cp-sidebar--collapsed .cp-sidebar__inner {
+  padding: 0.85rem 0.55rem;
+  align-items: center;
 }
 
 .cp-sidebar__brand {
   display: flex;
   align-items: center;
-  height: 2.5rem;
-  margin-bottom: 1.75rem;
+  min-height: 2.75rem;
+  margin-bottom: 1.25rem;
   flex-shrink: 0;
+  width: 100%;
+  position: relative;
+}
+
+.cp-sidebar__brand--collapsed {
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+.cp-sidebar__toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .cp-sidebar__nav {
   flex: 1 1 auto;
   min-height: 0;
+  min-width: 0;
+  width: 100%;
   overflow-y: auto;
-  overflow-x: hidden;
+  overflow-x: visible; /* don't clip active cyan frames */
   display: flex;
   flex-direction: column;
   justify-content: flex-start;
   align-items: stretch;
-  gap: 0.15rem;
+  gap: 0;
   -webkit-overflow-scrolling: touch;
+  padding: 2px 0; /* room for 1px borders on first/last items */
+}
+
+.cp-sidebar--collapsed .cp-sidebar__nav {
+  align-items: center;
+  gap: 0.35rem;
+  overflow-x: hidden; /* rail is narrow; items are sized to fit */
+  overflow-y: auto;
 }
 
 .cp-sidebar__nav > * {
   flex: 0 0 auto !important;
+  min-width: 0;
+}
+
+.cp-sidebar--collapsed .cp-sidebar__nav > * {
+  width: 100%;
+  display: flex;
+  justify-content: center;
 }
 
 .cp-sidebar__foot {
   flex-shrink: 0;
   margin-top: auto;
-  padding-top: 1.25rem;
+  padding-top: 1rem;
   border-top: 1px solid rgba(255, 255, 255, 0.06);
+  width: 100%;
+}
+
+.cp-sidebar--collapsed .cp-sidebar__foot {
+  display: flex;
+  justify-content: center;
+  padding-top: 0.75rem;
+  border-top-color: rgba(255, 60, 60, 0.2);
 }
 
 /* Token-driven shared components (both themes set these vars) */
@@ -224,14 +270,39 @@ body {
   border-radius: var(--radius-ps-xl);
 }
 
+/*
+ * Base nav chrome — both themes override look, but every theme gets
+ * readable padding + icon/label gap so Classic never ends up cramped.
+ */
 .cp-nav-item {
   color: var(--color-nav-idle) !important;
   background: transparent !important;
   border: 1px solid transparent !important;
   border-radius: var(--radius-nav) !important;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
   font-weight: 700;
+  font-family: var(--font-ui);
+  gap: 1rem;
+  box-sizing: border-box;
+}
+
+/* Sidebar: original pldmgr pill spacing */
+.cp-sidebar .cp-nav-item {
+  width: 100%;
+  padding: 1rem 1rem;
+  margin-bottom: 0.5rem;
+  min-height: 3.25rem;
+  justify-content: flex-start;
+}
+
+.cp-sidebar .cp-nav-item.justify-center {
+  justify-content: center;
+  margin-left: auto;
+  margin-right: auto;
+  width: auto;
+  min-width: 3.25rem;
+  padding: 0.85rem;
 }
 
 .cp-nav-item:hover {
@@ -328,6 +399,142 @@ button:focus {
   will-change: transform;
 }
 
+/* ── Settings cards ───────────────────────────────────────────────
+ * Fixed 3-column grid: icon | text (minmax 0,1fr) | control.
+ * Prevents wide toggles from crushing titles into one-word lines.
+ */
+.setting-row {
+  display: grid;
+  grid-template-columns: auto minmax(12rem, 1fr) auto;
+  grid-template-areas: "icon copy control";
+  column-gap: 1rem;
+  row-gap: 0.75rem;
+  align-items: center;
+  height: 100%;
+  padding: 1.25rem 1.25rem;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 1.5rem;
+  transition: border-color 0.2s ease, background 0.2s ease;
+  box-sizing: border-box;
+}
+
+@media (min-width: 768px) {
+  .setting-row {
+    padding: 1.75rem 2rem;
+    column-gap: 1.25rem;
+  }
+}
+
+.setting-row:hover {
+  border-color: rgba(0, 149, 255, 0.35);
+}
+
+.setting-row__icon {
+  grid-area: icon;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  padding: 0.75rem;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 1rem;
+  color: #71717a;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+@media (min-width: 768px) {
+  .setting-row__icon {
+    padding: 1rem;
+  }
+}
+
+.setting-row:hover .setting-row__icon {
+  background: rgba(0, 149, 255, 0.12);
+  color: var(--color-ps-blue);
+}
+
+.setting-row__copy {
+  grid-area: copy;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.setting-row__title {
+  margin: 0;
+  font-weight: 800;
+  color: #fff;
+  text-transform: uppercase;
+  font-size: 1rem;
+  line-height: 1.35;
+  letter-spacing: 0.02em;
+  overflow-wrap: normal;
+  word-break: normal;
+  white-space: normal;
+}
+
+@media (min-width: 768px) {
+  .setting-row__title {
+    font-size: 1.125rem;
+  }
+}
+
+.setting-row__desc {
+  margin: 0;
+  font-size: 0.875rem;
+  line-height: 1.55;
+  color: #71717a;
+  max-width: 36rem;
+}
+
+/* Control column — reserved width, never squeezes the copy column */
+.setting-row__control {
+  grid-area: control;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  align-self: center;
+  min-width: max-content;
+}
+
+/* Vertical variant (language picker): control under copy, full width */
+.setting-row--vertical {
+  grid-template-columns: auto minmax(0, 1fr);
+  grid-template-areas:
+    "icon copy"
+    "control control";
+  align-items: start;
+}
+
+.setting-row--vertical .setting-row__control {
+  justify-content: stretch;
+  width: 100%;
+  padding-top: 0.25rem;
+}
+
+.setting-row--vertical .setting-row__control > * {
+  width: 100%;
+}
+
+/* Narrow cards (two-up grid): stack control under text so titles keep room */
+@media (max-width: 1279px) {
+  .setting-row:not(.setting-row--vertical) {
+    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-areas:
+      "icon copy"
+      "control control";
+    align-items: start;
+  }
+
+  .setting-row:not(.setting-row--vertical) .setting-row__control {
+    justify-content: flex-end;
+    padding-top: 0.25rem;
+  }
+}
+
 /* Theme picker (token-driven) */
 .cp-theme-grid {
   display: grid;
@@ -381,4 +588,193 @@ button:focus {
   font-size: 12px;
   color: var(--color-muted);
   line-height: 1.4;
+}
+
+/* Autoload Delay settings card */
+.cp-delay-card {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  height: 100%;
+  padding: 1.5rem 1.75rem;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 1.5rem;
+  box-sizing: border-box;
+}
+
+.cp-delay-card__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.cp-delay-card__value {
+  flex-shrink: 0;
+  font-weight: 900;
+  font-size: 2.25rem;
+  font-style: italic;
+  letter-spacing: -0.03em;
+  color: var(--color-ps-blue);
+  line-height: 1;
+}
+
+.cp-delay-card__chips {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.75rem;
+}
+
+/* ── Fullscreen log overlay ─────────────────────────────────────── */
+.cp-log-overlay {
+  background: #08080a;
+  color: #e4e4e7;
+}
+
+.cp-log-overlay__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-shrink: 0;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(8, 8, 10, 0.96);
+  z-index: 20;
+}
+
+@media (min-width: 768px) {
+  .cp-log-overlay__header {
+    padding: 1.5rem 2rem;
+  }
+}
+
+.cp-log-overlay__title {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  min-width: 0;
+}
+
+.cp-log-overlay__title h3 {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 900;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-style: italic;
+  color: #fff;
+  line-height: 1.1;
+}
+
+@media (min-width: 768px) {
+  .cp-log-overlay__title h3 {
+    font-size: 2rem;
+  }
+}
+
+.cp-log-overlay__body {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  flex: 1 1 0%;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.cp-log-viewer {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0%;
+  min-height: 0;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.25);
+}
+
+.cp-log-viewer__scroll {
+  flex: 1 1 0%;
+  min-height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 1rem 1rem 5.5rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.8125rem;
+  line-height: 1.55;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  scroll-behavior: smooth;
+}
+
+@media (min-width: 768px) {
+  .cp-log-viewer__scroll {
+    padding: 1.5rem 2rem 6rem;
+    font-size: 0.9375rem;
+  }
+}
+
+.cp-log-viewer__empty {
+  padding: 3rem 1rem;
+  text-align: center;
+  color: #71717a;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.8rem;
+}
+
+.cp-log-viewer__pad {
+  height: 1rem;
+}
+
+/* Grid line: # | » | message — message wraps without crushing the gutter */
+.cp-log-line {
+  display: grid;
+  grid-template-columns: 2.75rem 1.1rem minmax(0, 1fr);
+  column-gap: 0.65rem;
+  align-items: start;
+  padding: 0.35rem 0.6rem;
+  border-left: 2px solid transparent;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+
+.cp-log-line:hover {
+  background: rgba(255, 255, 255, 0.04);
+  border-left-color: var(--color-ps-blue);
+}
+
+.cp-log-line__num {
+  font-weight: 700;
+  color: #52525b;
+  text-align: right;
+  user-select: none;
+  font-variant-numeric: tabular-nums;
+  white-space: pre;
+}
+
+.cp-log-line__prompt {
+  font-weight: 800;
+  color: var(--color-ps-blue);
+  opacity: 0.85;
+  user-select: none;
+  line-height: inherit;
+}
+
+.cp-log-line__text {
+  color: #e4e4e7;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  white-space: pre-wrap;
+}
+
+/* Jump-to-bottom control — always centered over the scrollport */
+.cp-log-viewer__jump {
+  position: absolute;
+  left: 50%;
+  bottom: 1.5rem;
+  transform: translateX(-50%);
+  z-index: 30;
+  pointer-events: auto;
+  filter: drop-shadow(0 8px 24px rgba(0, 0, 0, 0.55));
 }

--- a/frontend/src/theme/themes.js
+++ b/frontend/src/theme/themes.js
@@ -5,7 +5,7 @@
  */
 
 export const THEME_STORAGE_KEY = 'pldmgr-theme'
-export const DEFAULT_THEME = 'cyberpunk'
+export const DEFAULT_THEME = 'classic'
 
 /** Shared token keys — both themes must define every key. */
 export const THEME_VAR_KEYS = [

--- a/frontend/src/theme/themes.js
+++ b/frontend/src/theme/themes.js
@@ -1,0 +1,184 @@
+/**
+ * Payload Manager themes — fully isolated token sets.
+ * Every visual token is defined on BOTH themes so switching never leaves
+ * leftover values from the previous theme.
+ */
+
+export const THEME_STORAGE_KEY = 'pldmgr-theme'
+export const DEFAULT_THEME = 'cyberpunk'
+
+/** Shared token keys — both themes must define every key. */
+export const THEME_VAR_KEYS = [
+  '--color-ps-blue',
+  '--color-ps-blue-glow',
+  '--color-ps-yellow',
+  '--color-ps-red',
+  '--color-ps-black',
+  '--color-ps-surface',
+  '--color-ps-card',
+  '--color-ps-border',
+  '--color-nav-idle',
+  '--color-nav-active',
+  '--color-nav-active-bg',
+  '--color-nav-active-border',
+  '--color-nav-hover',
+  '--color-nav-hover-bg',
+  '--color-title-accent',
+  '--color-title-glow',
+  '--color-hud',
+  '--color-text',
+  '--color-muted',
+  '--color-scrollbar',
+  '--color-card-hover-bg',
+  '--color-card-hover-border',
+  '--color-card-hover-shadow',
+  '--color-brand',
+  '--color-brand-glow',
+  '--color-brand-icon-bg',
+  '--color-brand-icon-fg',
+  '--color-brand-icon-border',
+  '--color-brand-icon-shadow',
+  '--font-ui',
+  '--font-display',
+  '--radius-ps-xl',
+  '--radius-ps-2xl',
+  '--radius-ps-3xl',
+  '--radius-nav',
+  '--letter-spacing-body',
+  '--letter-spacing-heading',
+  '--text-transform-heading',
+  '--theme-atmosphere',
+]
+
+export const THEMES = {
+  classic: {
+    id: 'classic',
+    label: 'Classic',
+    description: 'Original PS blue manager look',
+    vars: {
+      '--color-ps-blue': '#0095ff',
+      '--color-ps-blue-glow': 'rgba(0, 149, 255, 0.4)',
+      '--color-ps-yellow': '#fcee0a',
+      '--color-ps-red': '#ef4444',
+      '--color-ps-black': '#08080a',
+      '--color-ps-surface': '#101014',
+      '--color-ps-card': 'rgba(24, 24, 28, 0.8)',
+      '--color-ps-border': 'rgba(255, 255, 255, 0.08)',
+      '--color-nav-idle': '#a1a1aa',
+      '--color-nav-active': '#ffffff',
+      '--color-nav-active-bg': '#0095ff',
+      '--color-nav-active-border': 'transparent',
+      '--color-nav-hover': '#ffffff',
+      '--color-nav-hover-bg': 'rgba(255, 255, 255, 0.05)',
+      '--color-title-accent': '#0095ff',
+      '--color-title-glow': 'transparent',
+      '--color-hud': 'rgba(255, 255, 255, 0.35)',
+      '--color-text': '#f4f4f5',
+      '--color-muted': '#a1a1aa',
+      '--color-scrollbar': 'rgba(255, 255, 255, 0.15)',
+      '--color-card-hover-bg': 'rgba(40, 40, 45, 0.95)',
+      '--color-card-hover-border': '#0095ff',
+      '--color-card-hover-shadow': 'none',
+      '--color-brand': '#ffffff',
+      '--color-brand-glow': 'transparent',
+      '--color-brand-icon-bg': '#0095ff',
+      '--color-brand-icon-fg': '#ffffff',
+      '--color-brand-icon-border': 'transparent',
+      '--color-brand-icon-shadow': 'none',
+      '--font-ui': 'system-ui, "Segoe UI", sans-serif',
+      '--font-display': 'system-ui, "Segoe UI", sans-serif',
+      '--radius-ps-xl': '1rem',
+      '--radius-ps-2xl': '1.5rem',
+      '--radius-ps-3xl': '2rem',
+      '--radius-nav': '1rem',
+      '--letter-spacing-body': 'normal',
+      '--letter-spacing-heading': '-0.025em',
+      '--text-transform-heading': 'none',
+      '--theme-atmosphere': '0',
+    },
+  },
+  cyberpunk: {
+    id: 'cyberpunk',
+    label: 'Cyberpunk 2077',
+    description: 'Night City HUD — red chrome, cyan select, code rain',
+    vars: {
+      '--color-ps-blue': '#00f0ff',
+      '--color-ps-blue-glow': 'rgba(0, 240, 255, 0.45)',
+      '--color-ps-yellow': '#fcee0a',
+      '--color-ps-red': '#ff3c3c',
+      '--color-ps-black': '#0a0508',
+      '--color-ps-surface': 'rgba(12, 4, 8, 0.92)',
+      '--color-ps-card': 'rgba(18, 6, 10, 0.82)',
+      '--color-ps-border': 'rgba(255, 60, 60, 0.28)',
+      '--color-nav-idle': 'rgba(255, 90, 90, 0.75)',
+      '--color-nav-active': '#00f0ff',
+      '--color-nav-active-bg': 'rgba(0, 240, 255, 0.04)',
+      '--color-nav-active-border': '#00f0ff',
+      '--color-nav-hover': '#ff9a9a',
+      '--color-nav-hover-bg': 'transparent',
+      '--color-title-accent': '#ff3c3c',
+      '--color-title-glow': 'rgba(255, 60, 60, 0.45)',
+      '--color-hud': 'rgba(255, 80, 80, 0.55)',
+      '--color-text': '#e8e4e0',
+      '--color-muted': '#7a6a68',
+      '--color-scrollbar': 'rgba(255, 60, 60, 0.35)',
+      '--color-card-hover-bg': 'rgba(20, 10, 16, 0.95)',
+      '--color-card-hover-border': 'rgba(0, 240, 255, 0.45)',
+      '--color-card-hover-shadow': '0 0 24px rgba(0, 240, 255, 0.12)',
+      '--color-brand': '#ff3c3c',
+      '--color-brand-glow': 'rgba(255, 60, 60, 0.55)',
+      '--color-brand-icon-bg': 'transparent',
+      '--color-brand-icon-fg': '#ff3c3c',
+      '--color-brand-icon-border': 'rgba(255, 60, 60, 0.5)',
+      '--color-brand-icon-shadow': '0 0 16px rgba(255, 60, 60, 0.25)',
+      '--font-ui': '"Share Tech Mono", Consolas, "Courier New", monospace',
+      '--font-display': '"Share Tech Mono", Consolas, monospace',
+      '--radius-ps-xl': '0.25rem',
+      '--radius-ps-2xl': '0.35rem',
+      '--radius-ps-3xl': '0.5rem',
+      '--radius-nav': '2px',
+      '--letter-spacing-body': '0.02em',
+      '--letter-spacing-heading': '0.04em',
+      '--text-transform-heading': 'uppercase',
+      '--theme-atmosphere': '1',
+    },
+  },
+}
+
+export function getTheme(id) {
+  return THEMES[id] || THEMES[DEFAULT_THEME]
+}
+
+/**
+ * Apply a theme with full isolation:
+ * - removes every known theme class
+ * - rewrites ALL theme CSS variables (complete set)
+ * - sets data-theme for CSS selectors
+ * - syncs body typography
+ */
+export function applyThemeVars(themeId) {
+  const theme = getTheme(themeId)
+  const root = document.documentElement
+
+  // Drop every theme-* class so nothing stacks
+  Array.from(root.classList).forEach((c) => {
+    if (c.startsWith('theme-')) root.classList.remove(c)
+  })
+  root.classList.add(`theme-${theme.id}`)
+  root.setAttribute('data-theme', theme.id)
+
+  // Write complete token set
+  THEME_VAR_KEYS.forEach((key) => {
+    const value = theme.vars[key]
+    if (value != null) root.style.setProperty(key, value)
+    else root.style.removeProperty(key)
+  })
+
+  // Body-level sync (avoids cached font / spacing artifacts)
+  if (document.body) {
+    document.body.style.fontFamily = theme.vars['--font-ui'] || ''
+    document.body.style.letterSpacing = theme.vars['--letter-spacing-body'] || 'normal'
+    document.body.style.color = theme.vars['--color-text'] || ''
+    document.body.style.backgroundColor = theme.vars['--color-ps-black'] || ''
+  }
+}

--- a/frontend/src/theme/themes.js
+++ b/frontend/src/theme/themes.js
@@ -1,13 +1,20 @@
 /**
- * Payload Manager themes — fully isolated token sets.
- * Every visual token is defined on BOTH themes so switching never leaves
- * leftover values from the previous theme.
+ * Payload Manager themes — pack registry + full isolation.
+ *
+ * To add a theme:
+ *   1. Add defineTheme(...) below (or import from ./packs/<id>.js)
+ *   2. Prefer extends + vars for palette skins; set skin only for a new chrome family
+ *   3. Optional: theme-*.css scoped with [data-skin="<family>"] or [data-theme="<id>"]
+ *   4. Optional: public/favicon-<id>.svg + favicon field
+ *   5. Import CSS in index.css if you add a new stylesheet
+ *
+ * Prefer hasFeature(...) over themeId === '…' in components.
  */
 
 export const THEME_STORAGE_KEY = 'pldmgr-theme'
 export const DEFAULT_THEME = 'classic'
 
-/** Shared token keys — both themes must define every key. */
+/** Shared token keys — every resolved theme must define every key. */
 export const THEME_VAR_KEYS = [
   '--color-ps-blue',
   '--color-ps-blue-glow',
@@ -50,111 +57,260 @@ export const THEME_VAR_KEYS = [
   '--theme-atmosphere',
 ]
 
-/** Favicon per theme (served from /public). */
+/**
+ * Feature flags — chrome modules / UX variants.
+ * Components should call hasFeature('atmosphere') instead of themeId === 'x'.
+ */
+export const FEATURE_DEFAULTS = {
+  /** Code rain / haze backdrop */
+  atmosphere: false,
+  /** Top HUD bar (version / IP) */
+  hudBar: false,
+  /** Yellow hazard stripe under top chrome */
+  hazardStripe: false,
+  /** FLATLINED death-screen errors (vs simple classic cards) */
+  flatlinedError: false,
+  /** Segmented OFF|ON toggles + cyber bar-style buttons */
+  hudControls: false,
+  /** Slightly denser main padding used by HUD layouts */
+  densePadding: false,
+}
+
+/** Built-in favicon map (public/). New themes can set favicon: '/favicon-x.svg'. */
 export const THEME_FAVICONS = {
   classic: '/favicon-classic.svg',
   cyberpunk: '/favicon-cyberpunk.svg',
 }
 
-export const THEMES = {
-  classic: {
-    id: 'classic',
-    label: 'Classic',
-    description: 'Original PS blue manager look',
-    favicon: THEME_FAVICONS.classic,
-    vars: {
-      '--color-ps-blue': '#0095ff',
-      '--color-ps-blue-glow': 'rgba(0, 149, 255, 0.4)',
-      '--color-ps-yellow': '#fcee0a',
-      '--color-ps-red': '#ef4444',
-      '--color-ps-black': '#08080a',
-      '--color-ps-surface': '#101014',
-      '--color-ps-card': 'rgba(24, 24, 28, 0.8)',
-      '--color-ps-border': 'rgba(255, 255, 255, 0.08)',
-      '--color-nav-idle': '#a1a1aa',
-      '--color-nav-active': '#ffffff',
-      '--color-nav-active-bg': '#0095ff',
-      '--color-nav-active-border': 'transparent',
-      '--color-nav-hover': '#ffffff',
-      '--color-nav-hover-bg': 'rgba(255, 255, 255, 0.05)',
-      '--color-title-accent': '#0095ff',
-      '--color-title-glow': 'transparent',
-      '--color-hud': 'rgba(255, 255, 255, 0.35)',
-      '--color-text': '#f4f4f5',
-      '--color-muted': '#a1a1aa',
-      '--color-scrollbar': 'rgba(255, 255, 255, 0.15)',
-      '--color-card-hover-bg': 'rgba(40, 40, 45, 0.95)',
-      '--color-card-hover-border': '#0095ff',
-      '--color-card-hover-shadow': 'none',
-      '--color-brand': '#ffffff',
-      '--color-brand-glow': 'transparent',
-      '--color-brand-icon-bg': '#0095ff',
-      '--color-brand-icon-fg': '#ffffff',
-      '--color-brand-icon-border': 'transparent',
-      '--color-brand-icon-shadow': 'none',
-      '--font-ui': 'system-ui, "Segoe UI", sans-serif',
-      '--font-display': 'system-ui, "Segoe UI", sans-serif',
-      '--radius-ps-xl': '1rem',
-      '--radius-ps-2xl': '1.5rem',
-      '--radius-ps-3xl': '2rem',
-      '--radius-nav': '1rem',
-      '--letter-spacing-body': 'normal',
-      '--letter-spacing-heading': '-0.025em',
-      '--text-transform-heading': 'none',
-      '--theme-atmosphere': '0',
-    },
+/** @type {Record<string, object>} */
+const THEME_DEFS = {}
+
+/**
+ * Register a theme pack.
+ *
+ * @param {string} id
+ * @param {object} opts
+ * @param {string} opts.label
+ * @param {string} [opts.description]
+ * @param {string} [opts.favicon]
+ * @param {string} [opts.extends] — id of base theme for vars + features + skin merge
+ * @param {string} [opts.skin] — CSS chrome family (`data-skin`). Defaults to id, or parent when extends.
+ *   Built-in skins: `classic` (theme-classic.css), `cyberpunk` (theme-cyberpunk.css).
+ * @param {Partial<typeof FEATURE_DEFAULTS>} [opts.features]
+ * @param {string[]} [opts.swatches] — Settings picker color chips
+ * @param {Record<string, string>} opts.vars — CSS custom properties (full or partial if extends)
+ */
+export function defineTheme(id, opts) {
+  if (!id || !opts?.label) {
+    throw new Error('defineTheme(id, { label, vars }) requires id and label')
+  }
+  THEME_DEFS[id] = { id, ...opts }
+  return THEME_DEFS[id]
+}
+
+function resolveThemeDef(id, seen = new Set()) {
+  const def = THEME_DEFS[id]
+  if (!def) return null
+  if (seen.has(id)) {
+    throw new Error(`Theme cycle detected at "${id}"`)
+  }
+  seen.add(id)
+
+  let baseVars = {}
+  let baseFeatures = { ...FEATURE_DEFAULTS }
+  let baseSkin = null
+  if (def.extends) {
+    const parent = resolveThemeDef(def.extends, seen)
+    if (!parent) {
+      throw new Error(`Theme "${id}" extends unknown theme "${def.extends}"`)
+    }
+    baseVars = { ...parent.vars }
+    baseFeatures = { ...parent.features }
+    baseSkin = parent.skin
+  }
+
+  const features = { ...baseFeatures, ...(def.features || {}) }
+  const vars = { ...baseVars, ...(def.vars || {}) }
+  // skin = explicit pack skin → parent skin (extends) → own id
+  const skin = def.skin || baseSkin || id
+
+  // Validate complete token set
+  const missing = THEME_VAR_KEYS.filter((k) => vars[k] == null || vars[k] === '')
+  if (missing.length) {
+    console.warn(`[theme] "${id}" missing CSS vars:`, missing.join(', '))
+  }
+
+  return {
+    id,
+    label: def.label,
+    description: def.description || '',
+    favicon: def.favicon || THEME_FAVICONS[id] || THEME_FAVICONS[DEFAULT_THEME],
+    skin,
+    swatches: def.swatches || [],
+    features,
+    vars,
+  }
+}
+
+// ── Packs ───────────────────────────────────────────────────────────
+
+defineTheme('classic', {
+  label: 'Classic',
+  description: 'Original PS blue manager look',
+  skin: 'classic',
+  favicon: THEME_FAVICONS.classic,
+  swatches: ['#0095ff', '#101014', '#ffffff', '#08080a'],
+  features: { ...FEATURE_DEFAULTS },
+  vars: {
+    '--color-ps-blue': '#0095ff',
+    '--color-ps-blue-glow': 'rgba(0, 149, 255, 0.4)',
+    '--color-ps-yellow': '#fcee0a',
+    '--color-ps-red': '#ef4444',
+    '--color-ps-black': '#08080a',
+    '--color-ps-surface': '#101014',
+    '--color-ps-card': 'rgba(24, 24, 28, 0.8)',
+    '--color-ps-border': 'rgba(255, 255, 255, 0.08)',
+    '--color-nav-idle': '#a1a1aa',
+    '--color-nav-active': '#ffffff',
+    '--color-nav-active-bg': '#0095ff',
+    '--color-nav-active-border': 'transparent',
+    '--color-nav-hover': '#ffffff',
+    '--color-nav-hover-bg': 'rgba(255, 255, 255, 0.05)',
+    '--color-title-accent': '#0095ff',
+    '--color-title-glow': 'transparent',
+    '--color-hud': 'rgba(255, 255, 255, 0.35)',
+    '--color-text': '#f4f4f5',
+    '--color-muted': '#a1a1aa',
+    '--color-scrollbar': 'rgba(255, 255, 255, 0.15)',
+    '--color-card-hover-bg': 'rgba(40, 40, 45, 0.95)',
+    '--color-card-hover-border': '#0095ff',
+    '--color-card-hover-shadow': 'none',
+    '--color-brand': '#ffffff',
+    '--color-brand-glow': 'transparent',
+    '--color-brand-icon-bg': '#0095ff',
+    '--color-brand-icon-fg': '#ffffff',
+    '--color-brand-icon-border': 'transparent',
+    '--color-brand-icon-shadow': 'none',
+    '--font-ui': 'system-ui, "Segoe UI", sans-serif',
+    '--font-display': 'system-ui, "Segoe UI", sans-serif',
+    '--radius-ps-xl': '1rem',
+    '--radius-ps-2xl': '1.5rem',
+    '--radius-ps-3xl': '2rem',
+    '--radius-nav': '1rem',
+    '--letter-spacing-body': 'normal',
+    '--letter-spacing-heading': '-0.025em',
+    '--text-transform-heading': 'none',
+    '--theme-atmosphere': '0',
   },
-  cyberpunk: {
-    id: 'cyberpunk',
-    label: 'Cyberpunk 2077',
-    description: 'Night City HUD — red chrome, cyan select, code rain',
-    favicon: THEME_FAVICONS.cyberpunk,
-    vars: {
-      '--color-ps-blue': '#00f0ff',
-      '--color-ps-blue-glow': 'rgba(0, 240, 255, 0.45)',
-      '--color-ps-yellow': '#fcee0a',
-      '--color-ps-red': '#ff3c3c',
-      '--color-ps-black': '#0a0508',
-      '--color-ps-surface': 'rgba(12, 4, 8, 0.92)',
-      '--color-ps-card': 'rgba(18, 6, 10, 0.82)',
-      '--color-ps-border': 'rgba(255, 60, 60, 0.28)',
-      '--color-nav-idle': 'rgba(255, 90, 90, 0.75)',
-      '--color-nav-active': '#00f0ff',
-      '--color-nav-active-bg': 'rgba(0, 240, 255, 0.04)',
-      '--color-nav-active-border': '#00f0ff',
-      '--color-nav-hover': '#ff9a9a',
-      '--color-nav-hover-bg': 'transparent',
-      '--color-title-accent': '#ff3c3c',
-      '--color-title-glow': 'rgba(255, 60, 60, 0.45)',
-      '--color-hud': 'rgba(255, 80, 80, 0.55)',
-      '--color-text': '#e8e4e0',
-      '--color-muted': '#7a6a68',
-      '--color-scrollbar': 'rgba(255, 60, 60, 0.35)',
-      '--color-card-hover-bg': 'rgba(20, 10, 16, 0.95)',
-      '--color-card-hover-border': 'rgba(0, 240, 255, 0.45)',
-      '--color-card-hover-shadow': '0 0 24px rgba(0, 240, 255, 0.12)',
-      '--color-brand': '#ff3c3c',
-      '--color-brand-glow': 'rgba(255, 60, 60, 0.55)',
-      '--color-brand-icon-bg': 'transparent',
-      '--color-brand-icon-fg': '#ff3c3c',
-      '--color-brand-icon-border': 'rgba(255, 60, 60, 0.5)',
-      '--color-brand-icon-shadow': '0 0 16px rgba(255, 60, 60, 0.25)',
-      '--font-ui': '"Share Tech Mono", Consolas, "Courier New", monospace',
-      '--font-display': '"Share Tech Mono", Consolas, monospace',
-      '--radius-ps-xl': '0.25rem',
-      '--radius-ps-2xl': '0.35rem',
-      '--radius-ps-3xl': '0.5rem',
-      '--radius-nav': '2px',
-      '--letter-spacing-body': '0.02em',
-      '--letter-spacing-heading': '0.04em',
-      '--text-transform-heading': 'uppercase',
-      '--theme-atmosphere': '1',
-    },
+})
+
+defineTheme('cyberpunk', {
+  label: 'Cyberpunk 2077',
+  description: 'Night City HUD — red chrome, cyan select, code rain',
+  skin: 'cyberpunk',
+  favicon: THEME_FAVICONS.cyberpunk,
+  swatches: ['#ff3c3c', '#00f0ff', '#fcee0a', '#0a0508'],
+  // Full token set (does not extend classic — different chrome family)
+  features: {
+    atmosphere: true,
+    hudBar: true,
+    hazardStripe: true,
+    flatlinedError: true,
+    hudControls: true,
+    densePadding: true,
   },
+  vars: {
+    '--color-ps-blue': '#00f0ff',
+    '--color-ps-blue-glow': 'rgba(0, 240, 255, 0.45)',
+    '--color-ps-yellow': '#fcee0a',
+    '--color-ps-red': '#ff3c3c',
+    '--color-ps-black': '#0a0508',
+    '--color-ps-surface': 'rgba(12, 4, 8, 0.92)',
+    '--color-ps-card': 'rgba(18, 6, 10, 0.82)',
+    '--color-ps-border': 'rgba(255, 60, 60, 0.28)',
+    '--color-nav-idle': 'rgba(255, 90, 90, 0.75)',
+    '--color-nav-active': '#00f0ff',
+    '--color-nav-active-bg': 'rgba(0, 240, 255, 0.04)',
+    '--color-nav-active-border': '#00f0ff',
+    '--color-nav-hover': '#ff9a9a',
+    '--color-nav-hover-bg': 'transparent',
+    '--color-title-accent': '#ff3c3c',
+    '--color-title-glow': 'rgba(255, 60, 60, 0.45)',
+    '--color-hud': 'rgba(255, 80, 80, 0.55)',
+    '--color-text': '#e8e4e0',
+    '--color-muted': '#7a6a68',
+    '--color-scrollbar': 'rgba(255, 60, 60, 0.35)',
+    '--color-card-hover-bg': 'rgba(20, 10, 16, 0.95)',
+    '--color-card-hover-border': 'rgba(0, 240, 255, 0.45)',
+    '--color-card-hover-shadow': '0 0 24px rgba(0, 240, 255, 0.12)',
+    '--color-brand': '#ff3c3c',
+    '--color-brand-glow': 'rgba(255, 60, 60, 0.55)',
+    '--color-brand-icon-bg': 'transparent',
+    '--color-brand-icon-fg': '#ff3c3c',
+    '--color-brand-icon-border': 'rgba(255, 60, 60, 0.5)',
+    '--color-brand-icon-shadow': '0 0 16px rgba(255, 60, 60, 0.25)',
+    '--font-ui': '"Share Tech Mono", Consolas, "Courier New", monospace',
+    '--font-display': '"Share Tech Mono", Consolas, monospace',
+    '--radius-ps-xl': '0.25rem',
+    '--radius-ps-2xl': '0.35rem',
+    '--radius-ps-3xl': '0.5rem',
+    '--radius-nav': '2px',
+    '--letter-spacing-body': '0.02em',
+    '--letter-spacing-heading': '0.04em',
+    '--text-transform-heading': 'uppercase',
+    '--theme-atmosphere': '1',
+  },
+})
+
+/**
+ * Example palette-only theme (inherits cyberpunk features + skin CSS).
+ * Uncomment to register — zero JSX changes; Settings grid picks it up automatically.
+ *
+ * defineTheme('matrix', {
+ *   label: 'Matrix',
+ *   description: 'HUD chrome with green phosphor palette',
+ *   extends: 'cyberpunk', // → skin: cyberpunk, all HUD features on
+ *   swatches: ['#00ff66', '#003311', '#0a0f0a', '#001a0a'],
+ *   favicon: '/favicon-cyberpunk.svg',
+ *   vars: {
+ *     '--color-ps-blue': '#00ff66',
+ *     '--color-ps-blue-glow': 'rgba(0, 255, 102, 0.45)',
+ *     '--color-ps-red': '#00cc55',
+ *     '--color-title-accent': '#00ff66',
+ *     '--color-nav-idle': 'rgba(0, 255, 100, 0.55)',
+ *     '--color-nav-active': '#00ff66',
+ *     '--color-brand': '#00ff66',
+ *     '--color-brand-icon-fg': '#00ff66',
+ *     '--color-brand-icon-border': 'rgba(0, 255, 100, 0.45)',
+ *     '--color-scrollbar': 'rgba(0, 255, 100, 0.35)',
+ *   },
+ * })
+ */
+
+// ── Resolved registry ───────────────────────────────────────────────
+
+function buildThemes() {
+  const out = {}
+  for (const id of Object.keys(THEME_DEFS)) {
+    out[id] = resolveThemeDef(id)
+  }
+  return out
+}
+
+export const THEMES = buildThemes()
+
+export function listThemes() {
+  return Object.values(THEMES)
 }
 
 export function getTheme(id) {
   return THEMES[id] || THEMES[DEFAULT_THEME]
+}
+
+/** @param {string} themeId @param {keyof typeof FEATURE_DEFAULTS} feature */
+export function themeHasFeature(themeId, feature) {
+  const theme = getTheme(themeId)
+  return !!theme.features?.[feature]
 }
 
 /**
@@ -164,12 +320,7 @@ export function getTheme(id) {
 export function applyThemeFavicon(themeId) {
   if (typeof document === 'undefined') return
   const theme = getTheme(themeId)
-  const href =
-    theme.favicon ||
-    THEME_FAVICONS[theme.id] ||
-    THEME_FAVICONS[DEFAULT_THEME] ||
-    '/favicon-classic.svg'
-  // query param forces refresh when theme flips
+  const href = theme.favicon || THEME_FAVICONS[DEFAULT_THEME] || '/favicon-classic.svg'
   const bust = `${href}?theme=${encodeURIComponent(theme.id)}`
 
   let link = document.querySelector('link[rel="icon"][data-theme-favicon]')
@@ -199,22 +350,28 @@ export function applyThemeFavicon(themeId) {
 export function applyThemeVars(themeId) {
   const theme = getTheme(themeId)
   const root = document.documentElement
+  const skin = theme.skin || theme.id
 
-  // Drop every theme-* class so nothing stacks
   Array.from(root.classList).forEach((c) => {
-    if (c.startsWith('theme-')) root.classList.remove(c)
+    if (c.startsWith('theme-') || c.startsWith('skin-')) root.classList.remove(c)
   })
   root.classList.add(`theme-${theme.id}`)
+  root.classList.add(`skin-${skin}`)
+  // data-theme = pack id (identity); data-skin = CSS chrome family (classic | cyberpunk | …)
   root.setAttribute('data-theme', theme.id)
+  root.setAttribute('data-skin', skin)
 
-  // Write complete token set
+  // Feature flags as data attributes for pure-CSS optional chrome
+  Object.entries(theme.features || {}).forEach(([key, on]) => {
+    root.setAttribute(`data-feature-${key}`, on ? '1' : '0')
+  })
+
   THEME_VAR_KEYS.forEach((key) => {
     const value = theme.vars[key]
     if (value != null) root.style.setProperty(key, value)
     else root.style.removeProperty(key)
   })
 
-  // Body-level sync (avoids cached font / spacing artifacts)
   if (document.body) {
     document.body.style.fontFamily = theme.vars['--font-ui'] || ''
     document.body.style.letterSpacing = theme.vars['--letter-spacing-body'] || 'normal'

--- a/frontend/src/theme/themes.js
+++ b/frontend/src/theme/themes.js
@@ -50,11 +50,18 @@ export const THEME_VAR_KEYS = [
   '--theme-atmosphere',
 ]
 
+/** Favicon per theme (served from /public). */
+export const THEME_FAVICONS = {
+  classic: '/favicon-classic.svg',
+  cyberpunk: '/favicon-cyberpunk.svg',
+}
+
 export const THEMES = {
   classic: {
     id: 'classic',
     label: 'Classic',
     description: 'Original PS blue manager look',
+    favicon: THEME_FAVICONS.classic,
     vars: {
       '--color-ps-blue': '#0095ff',
       '--color-ps-blue-glow': 'rgba(0, 149, 255, 0.4)',
@@ -101,6 +108,7 @@ export const THEMES = {
     id: 'cyberpunk',
     label: 'Cyberpunk 2077',
     description: 'Night City HUD — red chrome, cyan select, code rain',
+    favicon: THEME_FAVICONS.cyberpunk,
     vars: {
       '--color-ps-blue': '#00f0ff',
       '--color-ps-blue-glow': 'rgba(0, 240, 255, 0.45)',
@@ -150,11 +158,43 @@ export function getTheme(id) {
 }
 
 /**
+ * Swap tab favicon for the active theme.
+ * Cache-bust so browsers actually repaint when switching.
+ */
+export function applyThemeFavicon(themeId) {
+  if (typeof document === 'undefined') return
+  const theme = getTheme(themeId)
+  const href =
+    theme.favicon ||
+    THEME_FAVICONS[theme.id] ||
+    THEME_FAVICONS[DEFAULT_THEME] ||
+    '/favicon-classic.svg'
+  // query param forces refresh when theme flips
+  const bust = `${href}?theme=${encodeURIComponent(theme.id)}`
+
+  let link = document.querySelector('link[rel="icon"][data-theme-favicon]')
+  if (!link) {
+    link = document.querySelector('link[rel="icon"][type="image/svg+xml"]')
+  }
+  if (!link) {
+    link = document.createElement('link')
+    link.setAttribute('rel', 'icon')
+    link.setAttribute('type', 'image/svg+xml')
+    link.setAttribute('data-theme-favicon', '1')
+    document.head.appendChild(link)
+  }
+  link.setAttribute('type', 'image/svg+xml')
+  link.setAttribute('data-theme-favicon', '1')
+  link.setAttribute('href', bust)
+}
+
+/**
  * Apply a theme with full isolation:
  * - removes every known theme class
  * - rewrites ALL theme CSS variables (complete set)
  * - sets data-theme for CSS selectors
  * - syncs body typography
+ * - swaps favicon for the selected theme
  */
 export function applyThemeVars(themeId) {
   const theme = getTheme(themeId)
@@ -181,4 +221,6 @@ export function applyThemeVars(themeId) {
     document.body.style.color = theme.vars['--color-text'] || ''
     document.body.style.backgroundColor = theme.vars['--color-ps-black'] || ''
   }
+
+  applyThemeFavicon(theme.id)
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -7,21 +7,30 @@ export default {
   theme: {
     extend: {
       colors: {
-        'ps-blue': '#0095ff',
-        'ps-blue-glow': 'rgba(0, 149, 255, 0.4)',
-        'ps-black': '#08080a',
-        'ps-surface': '#101014',
-        'ps-card': 'rgba(24, 24, 28, 0.8)',
-        'ps-border': 'rgba(255, 255, 255, 0.08)',
+        // Kept as ps-* so existing classes work — values are Night City palette
+        'ps-blue': '#00f0ff',
+        'ps-blue-glow': 'rgba(0, 240, 255, 0.4)',
+        'ps-yellow': '#fcee0a',
+        'ps-red': '#ff3c3c',
+        'ps-black': '#05040a',
+        'ps-surface': '#0a080c',
+        'ps-card': 'rgba(12, 8, 14, 0.88)',
+        'ps-border': 'rgba(255, 60, 60, 0.18)',
       },
       borderRadius: {
-        'ps-xl': '1rem',
-        'ps-2xl': '1.5rem',
-        'ps-3xl': '2rem',
+        'ps-xl': '0.75rem',
+        'ps-2xl': '1rem',
+        'ps-3xl': '1.25rem',
       },
       fontFamily: {
-        'ps5': ["Inter", "system-ui", "sans-serif"],
-      }
+        'ps5': ['"Share Tech Mono"', 'Consolas', 'monospace'],
+        'display': ['Orbitron', 'Oxanium', 'system-ui', 'sans-serif'],
+      },
+      boxShadow: {
+        'cp-cyan': '0 0 24px rgba(0, 240, 255, 0.25)',
+        'cp-yellow': '0 0 24px rgba(252, 238, 10, 0.25)',
+        'cp-red': '0 0 24px rgba(255, 60, 60, 0.2)',
+      },
     },
   },
   plugins: [],

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -7,24 +7,24 @@ export default {
   theme: {
     extend: {
       colors: {
-        // Kept as ps-* so existing classes work — values are Night City palette
-        'ps-blue': '#00f0ff',
-        'ps-blue-glow': 'rgba(0, 240, 255, 0.4)',
-        'ps-yellow': '#fcee0a',
-        'ps-red': '#ff3c3c',
-        'ps-black': '#05040a',
-        'ps-surface': '#0a080c',
-        'ps-card': 'rgba(12, 8, 14, 0.88)',
-        'ps-border': 'rgba(255, 60, 60, 0.18)',
+        // Resolve through CSS custom properties so Classic/Cyberpunk switch works
+        'ps-blue': 'var(--color-ps-blue)',
+        'ps-blue-glow': 'var(--color-ps-blue-glow)',
+        'ps-yellow': 'var(--color-ps-yellow)',
+        'ps-red': 'var(--color-ps-red)',
+        'ps-black': 'var(--color-ps-black)',
+        'ps-surface': 'var(--color-ps-surface)',
+        'ps-card': 'var(--color-ps-card)',
+        'ps-border': 'var(--color-ps-border)',
       },
       borderRadius: {
-        'ps-xl': '0.75rem',
-        'ps-2xl': '1rem',
-        'ps-3xl': '1.25rem',
+        'ps-xl': 'var(--radius-ps-xl)',
+        'ps-2xl': 'var(--radius-ps-2xl)',
+        'ps-3xl': 'var(--radius-ps-3xl)',
       },
       fontFamily: {
-        'ps5': ['"Share Tech Mono"', 'Consolas', 'monospace'],
-        'display': ['Orbitron', 'Oxanium', 'system-ui', 'sans-serif'],
+        'ps5': 'var(--font-ui)',
+        'display': 'var(--font-display)',
       },
       boxShadow: {
         'cp-cyan': '0 0 24px rgba(0, 240, 255, 0.25)',


### PR DESCRIPTION
Adds an optional Cyberpunk 2077 HUD theme to Payload Manager while keeping the original Classic look as a first-class theme. Themes are isolated via a full CSS token set + data-theme, so switching does not leave mixed styles.

Dual-theme system
• Theme registry + token application (frontend/src/theme/themes.js)
• Shared UI uses CSS variables; overrides in theme-classic.css / theme-cyberpunk.css
• Settings Appearance picker (persisted in localStorage as pldmgr-theme)
• Default theme: Classic (DEFAULT_THEME = 'classic')

Cyberpunk theme
• Night City palette (coral red / cyan / yellow)
• Atmosphere (code rain, haze), HUD bar, hazard stripe (cyberpunk only)
• Cut-corner chrome, yellow ticks, HUD-style actions
• Autoload overlay themed for cyberpunk
• FLATLINED offline / process-error death screen (cyberpunk only)

Classic theme (default)
• Original PS blue manager look
• Original offline card (“Payload Manager is not running…”)
• Original Active Processes error panel (AlertTriangle + Retry)
• No code rain / FLATLINED chrome

Theme favicons
• Classic → blue SVG tab icon
• Cyberpunk → red/yellow SVG tab icon
• Updates when the theme changes (applyThemeFavicon)

UX polish
• Language dropdown capped width so long locale labels don’t break the settings grid
• HTML <title>: Payload Manager in dev; versioned title injected on release (make frontend-build)

───

Test plan
• [x] Fresh load / cleared localStorage → Classic theme and blue favicon
• [x] Switch to Cyberpunk → HUD chrome + cyberpunk favicon
• [x] Switch back to Classic → no leftover red rain / flatlined styles
• [x] Classic: offline + Active Processes error use original simple UIs
• [x] Cyberpunk: offline + process error use FLATLINED
• [x] Change language (e.g. Italian, German) → settings cards stay aligned; language select doesn’t spill