### PR TITLE
fix(storage): show sidecar version in installed payloads

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -38,6 +38,10 @@ import LogViewer from './components/views/LogViewer'
 import ManageSourcesView from './components/views/ManageSourcesView'
 import ActiveProcessesView from './components/views/ActiveProcessesView'
 
+// Convert a payload path to its display name (e.g., "/data/pldmgr/ftp_srv/ftp_srv_v1.elf" → "ftp srv v1")
+const getDisplayName = (path) =>
+  path.split('/').pop().replace(/\.(elf|bin)$/i, '').replace(/_/g, ' ')
+
 function App() {
   const { t } = useTranslation();
   const [view, setView] = useState('dashboard')
@@ -201,7 +205,7 @@ function App() {
   }
 
   const loadPayload = async (path) => {
-    const name = path.split('/').pop().replace(/\.(elf|bin)$/i, '').replace(/_/g, ' ')
+    const name = getDisplayName(path)
     setLoading(true)
     setActiveLoadingName(name)
     try {
@@ -553,22 +557,26 @@ function App() {
               "grid gap-4 md:gap-6 transition-all",
               isPS5 ? "grid-cols-3 xl:grid-cols-4" : "grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
             )
-            const makeCard = (p) => (
-              <PayloadButton
-                key={p}
-                path={p}
-                onClick={() => isFavoriteEditMode ? toggleFavorite(p) : loadPayload(p)}
-                isLoading={loading && activeLoadingName === p.split('/').pop().replace(/\.(elf|bin)$/i, '').replace(/_/g, ' ')}
-                sourceName={config.MULTI_SOURCES_ENABLED ? (payloadMeta[p.split('/').pop()]?.source_name || null) : null}
-                version={payloadMeta[p.split('/').pop()]?.version || null}
-                isFavorite={favoritePayloads.includes(p)}
-                isLaunched={launchHistory.includes(p)}
-                isEditMode={isFavoriteEditMode}
-                onMoveFavorite={moveFavorite}
-                canMoveLeft={activeFavorites.indexOf(p) > 0}
-                canMoveRight={activeFavorites.indexOf(p) < activeFavorites.length - 1}
-              />
-            )
+            const makeCard = (p) => {
+              const fileName = p.split('/').pop()
+              const meta = payloadMeta[fileName]
+              return (
+                <PayloadButton
+                  key={p}
+                  path={p}
+                  onClick={() => isFavoriteEditMode ? toggleFavorite(p) : loadPayload(p)}
+                  isLoading={loading && activeLoadingName === getDisplayName(p)}
+                  sourceName={config.MULTI_SOURCES_ENABLED ? (meta?.source_name || null) : null}
+                  version={meta?.version || null}
+                  isFavorite={favoritePayloads.includes(p)}
+                  isLaunched={launchHistory.includes(p)}
+                  isEditMode={isFavoriteEditMode}
+                  onMoveFavorite={moveFavorite}
+                  canMoveLeft={activeFavorites.indexOf(p) > 0}
+                  canMoveRight={activeFavorites.indexOf(p) < activeFavorites.length - 1}
+                />
+              )
+            }
             return (
               <div className={cn(
                 "space-y-8 md:space-y-12 transition-all",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -685,6 +685,7 @@ function App() {
           {view === 'autoload' && (
             <AutoloadView
               payloads={payloads}
+              payloadMeta={payloadMeta}
               config={config}
               onSaveConfig={handleSaveConfig}
               onToast={addToast}

--- a/frontend/src/components/views/AutoloadView.jsx
+++ b/frontend/src/components/views/AutoloadView.jsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import PayloadName from '../ui/PayloadName'
 import Modal from '../ui/Modal'
 
-const AutoloadView = ({ payloads, config, onSaveConfig, onToast, onRedirect }) => {
+const AutoloadView = ({ payloads, payloadMeta = {}, config, onSaveConfig, onToast, onRedirect }) => {
   const { t } = useTranslation()
   const [subView, setSubView] = useState('list')
   const [enabled, setEnabled] = useState(false)
@@ -127,7 +127,7 @@ const AutoloadView = ({ payloads, config, onSaveConfig, onToast, onRedirect }) =
                   isBlocked ? "opacity-40 cursor-not-allowed" : "bg-white/[0.03] hover:border-ps-blue group"
                 )}
               >
-                <PayloadName path={p} className={cn("text-xl", isBlocked ? "text-zinc-500" : "text-white")} stacked />
+                <PayloadName path={p} version={payloadMeta[p]?.version || null} className={cn("text-xl", isBlocked ? "text-zinc-500" : "text-white")} stacked />
                 <ArrowRight className={cn("w-6 h-6 transition-all shrink-0 mt-1", isBlocked ? "text-zinc-800" : "text-zinc-500 group-hover:text-ps-blue group-hover:translate-x-2")} />
               </button>
             )
@@ -198,7 +198,7 @@ const AutoloadView = ({ payloads, config, onSaveConfig, onToast, onRedirect }) =
                 <span className="text-gray-500 text-[12px] font-black">{i + 1}</span>
               </div>
               <div className="flex items-center min-w-0 pl-2">
-                <PayloadName path={p} className="text-white" stacked />
+                <PayloadName path={p} version={payloadMeta[p]?.version || null} className="text-white" stacked />
               </div>
               <div className="flex items-center space-x-2">
                 <button onClick={() => moveUp(i)} disabled={i === 0} className="p-2 bg-white/10 text-zinc-400 hover:bg-ps-blue hover:text-white rounded-xl disabled:opacity-20">

--- a/frontend/src/components/views/StorageHub.jsx
+++ b/frontend/src/components/views/StorageHub.jsx
@@ -243,7 +243,7 @@ const StorageHub = ({ payloads, payloadMeta, onInstall, onDelete, onUpload, onIm
                         <Package className="w-6 h-6 md:w-8 md:h-8 text-zinc-400 group-hover:text-ps-blue transition-colors" />
                       </div>
                       <div className="min-w-0 flex-1 space-y-1">
-                        <PayloadName path={fileName} className="text-xl md:text-2xl text-white" stacked />
+                        <PayloadName path={fileName} version={payloadMeta[fileName]?.version || null} className="text-xl md:text-2xl text-white" stacked />
                         {sourceBadge && (
                           <div className="flex items-center gap-1 text-zinc-500 text-[11px] select-none font-medium">
                             <Globe className="w-3.5 h-3.5" />


### PR DESCRIPTION
## Problem

Payloads without a version string in the filename (e.g. `kylin-core.elf`, `shadowmountplus.elf`) show no version label in the Installed Payloads list, even though the sidecar metadata already contains a `version` field.

The dashboard's `PayloadButton` already passes the version via `payloadMeta[filename].version`, but the storage page's `PayloadName` was missing the same prop — so the two pages render the same payload inconsistently.

## Fix

Pass `payloadMeta[fileName]?.version` to `PayloadName` in the installed list. Falls back to filename-based parsing when sidecar metadata is absent.

While here, also extract `getDisplayName` in App.jsx so `loadPayload` and `makeCard` share the same path-to-name conversion (previously duplicated inline).

## Test plan

- `kylin-core.elf` (no version in filename, sidecar version present) → now shows `v1.3.1-community-lite`
- `ftpsrv_v0.21.elf` (version in filename) → still shows `v0.21`
- `npm run build` and `npm run lint` clean