### PR TITLE
fix(storage): scope update detection to the same source repo

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "dev:mock": "concurrently \"npm run mock\" \"npm run dev\"",
     "build": "vite build",
     "lint": "eslint .",
+    "test": "node --test src/utils/payloadStatus.test.js",
     "preview": "vite preview",
     "extract": "i18next"
   },

--- a/frontend/src/components/views/StorageHub.jsx
+++ b/frontend/src/components/views/StorageHub.jsx
@@ -3,6 +3,7 @@ import { CloudDownload, Upload, Package, Database, RefreshCw, Trash2, Loader2, A
 import { useTranslation } from 'react-i18next'
 import { QRCodeSVG } from 'qrcode.react'
 import { cn, isPS5, isIOS, parsePayloadName } from '../../utils/helpers'
+import { getInstalledPayloads, getPayloadStatus, isUsbPayloadPath } from '../../utils/payloadStatus'
 import PayloadName from '../ui/PayloadName'
 
 const PayloadItem = ({ p, multiSources, isPS5, onInstall, srcId, srcUrl }) => {
@@ -136,26 +137,12 @@ const StorageHub = ({ payloads, payloadMeta, onInstall, onDelete, onUpload, onIm
     }
   }, [scrollTarget]);
 
-  const localFilenames = useMemo(() => payloads.map(p => p.split('/').pop()), [payloads])
-  const internalPayloads = payloads.filter(p => !p.includes('/mnt/usb'))
-
-  const getBaseName = (filename) => {
-    if (!filename) return '';
-    let clean = filename.replace(/\.(elf|bin)$/i, '');
-    const versionMatch = clean.match(/[_-]v?(\d+[\d.a-z-]+)/i);
-    if (versionMatch) clean = clean.replace(versionMatch[0], '');
-    return clean.replace(/[_-]ps[45]$/i, '');
-  }
+  const installedPayloads = useMemo(() => getInstalledPayloads(payloads, payloadMeta), [payloads, payloadMeta])
+  const internalPayloads = payloads.filter(p => !isUsbPayloadPath(p))
 
   /* ---- Derive remote status for a flat list of payloads ---- */
   const enrichPayloads = (list) =>
-    list.map(p => {
-      const isInstalled = p.filename ? localFilenames.includes(p.filename) : false
-      const baseName = getBaseName(p.filename)
-      const installedVersion = localFilenames.find(f => getBaseName(f) === baseName)
-      const isUpdate = !isInstalled && !!installedVersion
-      return { ...p, isInstalled, isUpdate, installedFilename: installedVersion }
-    }).sort((a, b) => {
+    list.map(p => getPayloadStatus(p, installedPayloads)).sort((a, b) => {
       if (a.isUpdate && !b.isUpdate) return -1
       if (!a.isUpdate && b.isUpdate) return 1
       
@@ -170,7 +157,12 @@ const StorageHub = ({ payloads, payloadMeta, onInstall, onDelete, onUpload, onIm
       return repoData.sources.map(src => ({
         ...src,
         id: src.id || src.url,
-        payloads: enrichPayloads(src.payloads || [])
+        payloads: enrichPayloads((src.payloads || []).map(p => ({
+          ...p,
+          source_id: p.source_id || src.id,
+          source_name: p.source_name || src.name,
+          source_url: p.source_url || src.url || ''
+        })))
       }))
     } else if (!multiSources && repoData?.payloads) {
       return [{
@@ -178,11 +170,16 @@ const StorageHub = ({ payloads, payloadMeta, onInstall, onDelete, onUpload, onIm
         name: t("storage_hub.default_repository", "Default Repository"),
         url: repoData.repo_url || '',
         last_update: repoData.last_update || 0,
-        payloads: enrichPayloads(repoData.payloads)
+        payloads: enrichPayloads(repoData.payloads.map(p => ({
+          ...p,
+          source_id: p.source_id || 'legacy-repo',
+          source_name: p.source_name || t("storage_hub.default_repository", "Default Repository"),
+          source_url: p.source_url || repoData.repo_url || ''
+        })))
       }]
     }
     return []
-  }, [repoData, multiSources, localFilenames, t])
+  }, [repoData, multiSources, installedPayloads, t])
 
   const legacyRepoUrl = repoData?.repo_url || ''
 
@@ -233,7 +230,7 @@ const StorageHub = ({ payloads, payloadMeta, onInstall, onDelete, onUpload, onIm
               const sourceBadge = getSourceBadge(fileName)
               // Find update in all sources (multi or legacy)
               const allRemote = enrichedSources.flatMap(s => s.payloads)
-              const remoteMatch = allRemote.find(rp => rp.filename === fileName || rp.installedFilename === fileName)
+              const remoteMatch = allRemote.find(rp => rp.isUpdate && rp.installedFilename === fileName)
               const remoteVersion = remoteMatch?.version || (remoteMatch?.filename ? parsePayloadName(remoteMatch.filename).version : null)
               return (
                 <div key={path} className="group flex flex-col justify-center p-4 md:p-6 glass-card rounded-ps-2xl border-white/10 hover:border-ps-blue/30 gap-3 md:gap-4 relative overflow-hidden">
@@ -264,7 +261,7 @@ const StorageHub = ({ payloads, payloadMeta, onInstall, onDelete, onUpload, onIm
                   </div>
                   {remoteMatch?.isUpdate && (
                     <button
-                      onClick={() => onInstall(remoteMatch, remoteMatch.source_id, legacyRepoUrl)}
+                      onClick={() => onInstall(remoteMatch, remoteMatch.source_id, remoteMatch.source_url || legacyRepoUrl)}
                       className="w-full flex items-center justify-center space-x-2 py-2 bg-emerald-600 hover:bg-emerald-500 text-white rounded-xl font-bold text-xs md:text-sm transition-all"
                     >
                       <RefreshCw className="w-4 h-4 md:w-5 md:h-5" />

--- a/frontend/src/utils/payloadStatus.js
+++ b/frontend/src/utils/payloadStatus.js
@@ -1,0 +1,110 @@
+const getVersionFromFilename = (filename) => {
+  const name = (filename || '').replace(/\.(elf|bin)$/i, '')
+  const match = name.match(/[_-](v?\d+[\d.a-z-]+)/i)
+  return match ? match[1] : ''
+}
+
+export const getPayloadBaseName = (filename) => {
+  let clean = (filename || '').replace(/\.(elf|bin)$/i, '')
+  const versionMatch = clean.match(/[_-]v?(\d+[\d.a-z-]+)/i)
+  if (versionMatch) clean = clean.replace(versionMatch[0], '')
+  return clean.replace(/[_-]ps[45]$/i, '')
+}
+
+export const getPayloadVersion = (payload) => {
+  const version = payload?.version?.trim()
+  return version || getVersionFromFilename(payload?.filename)
+}
+
+const normalizeVersion = (version) => version.trim().replace(/^v/i, '').toLowerCase()
+
+const hasMatchingVersion = (remoteVersion, installedVersion) => (
+  remoteVersion && installedVersion &&
+  normalizeVersion(remoteVersion) === normalizeVersion(installedVersion)
+)
+
+const normalizeRepositoryUrl = (value) => (
+  (value || '').trim().replace(/\/+$/, '')
+)
+
+const normalizeRepositoryIdentity = (value) => (
+  (value || '').trim().replace(/\/+$/, '').toLowerCase()
+)
+
+const getSourceUrl = (payload) => (
+  payload?.sourceUrl || payload?.source_url ||
+  ((payload?.installSource || payload?.install_source) === 'repository'
+    ? (payload?.installSourceDetail || payload?.install_source_detail)
+    : '')
+)
+
+const getSourceId = (payload) => payload?.sourceId || payload?.source_id || payload?.source || ''
+
+const getSourceName = (payload) => (
+  payload?.sourceName || payload?.source_name || payload?.source_direct || ''
+)
+
+const isSameRepository = (remotePayload, installedPayload) => {
+  if ((installedPayload.installSource || installedPayload.install_source) === 'usb') return false
+
+  const remoteUrl = normalizeRepositoryUrl(getSourceUrl(remotePayload))
+  const installedUrl = normalizeRepositoryUrl(getSourceUrl(installedPayload))
+  if (remoteUrl && installedUrl) return remoteUrl === installedUrl
+
+  const remoteId = normalizeRepositoryIdentity(getSourceId(remotePayload))
+  const installedId = normalizeRepositoryIdentity(getSourceId(installedPayload))
+  if (remoteId && installedId) return remoteId === installedId
+
+  const remoteName = normalizeRepositoryIdentity(getSourceName(remotePayload))
+  const installedName = normalizeRepositoryIdentity(getSourceName(installedPayload))
+  if (remoteName && installedName) return remoteName === installedName
+
+  return true
+}
+
+export const isUsbPayloadPath = (path) => path.includes('/mnt/usb')
+
+export const getInstalledPayloads = (payloadPaths = [], payloadMeta = {}) => (
+  payloadPaths
+    .filter((path) => !isUsbPayloadPath(path))
+    .map((path) => {
+      const filename = path.split('/').pop()
+      const metadata = payloadMeta[filename] || {}
+
+      return {
+        filename,
+        version: metadata.version || getPayloadVersion({ filename }),
+        sourceId: metadata.source || '',
+        sourceName: metadata.source_name || metadata.source_direct || '',
+        sourceUrl: metadata.install_source === 'repository'
+          ? metadata.install_source_detail || ''
+          : '',
+        installSource: metadata.install_source || ''
+      }
+    })
+)
+
+export const getPayloadStatus = (remotePayload, installedPayloads) => {
+  const repositoryPayloads = installedPayloads.filter((installedPayload) => (
+    isSameRepository(remotePayload, installedPayload)
+  ))
+  const exactMatch = repositoryPayloads.find(({ filename }) => filename === remotePayload.filename)
+  const baseName = getPayloadBaseName(remotePayload.filename)
+  const baseMatch = repositoryPayloads.find(({ filename }) => getPayloadBaseName(filename) === baseName)
+  const remoteVersion = getPayloadVersion(remotePayload)
+  const versionMatch = repositoryPayloads.find((installedPayload) => (
+    getPayloadBaseName(installedPayload.filename) === baseName &&
+    hasMatchingVersion(remoteVersion, getPayloadVersion(installedPayload))
+  ))
+  const exactMatchHasDifferentVersion = exactMatch && remoteVersion &&
+    getPayloadVersion(exactMatch) &&
+    !hasMatchingVersion(remoteVersion, getPayloadVersion(exactMatch))
+  const isInstalled = Boolean(versionMatch || (exactMatch && !exactMatchHasDifferentVersion))
+
+  return {
+    ...remotePayload,
+    isInstalled,
+    isUpdate: !isInstalled && Boolean(baseMatch),
+    installedFilename: (exactMatch || versionMatch || baseMatch)?.filename
+  }
+}

--- a/frontend/src/utils/payloadStatus.test.js
+++ b/frontend/src/utils/payloadStatus.test.js
@@ -1,0 +1,146 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { getInstalledPayloads, getPayloadStatus } from './payloadStatus.js'
+
+test('同一插件在不同仓库声明相同版本时不显示更新', () => {
+  const status = getPayloadStatus(
+    { filename: 'etaHEN-v1.8.elf', version: 'v1.8' },
+    [{ filename: 'etaHEN_v1.8.elf', version: '1.8' }]
+  )
+
+  assert.equal(status.isInstalled, true)
+  assert.equal(status.isUpdate, false)
+  assert.equal(status.installedFilename, 'etaHEN_v1.8.elf')
+})
+
+test('同一插件有更高版本时仍显示更新', () => {
+  const status = getPayloadStatus(
+    { filename: 'etaHEN_v1.9.elf', version: 'v1.9' },
+    [{ filename: 'etaHEN_v1.8.elf', version: 'v1.8' }]
+  )
+
+  assert.equal(status.isInstalled, false)
+  assert.equal(status.isUpdate, true)
+  assert.equal(status.installedFilename, 'etaHEN_v1.8.elf')
+})
+
+test('缺失元数据版本时按文件名版本判定', () => {
+  const status = getPayloadStatus(
+    { filename: 'ftpsrv-v0.19.elf' },
+    [{ filename: 'ftpsrv_v0.19.elf', version: '' }]
+  )
+
+  assert.equal(status.isInstalled, true)
+  assert.equal(status.isUpdate, false)
+})
+
+test('同一仓库同名文件但版本变化时显示更新', () => {
+  const status = getPayloadStatus(
+    {
+      filename: 'ftpsrv-ps5.elf',
+      version: '1.15-ng-stable',
+      source_url: 'https://github.com/drakmor/ftpsrv'
+    },
+    [{
+      filename: 'ftpsrv-ps5.elf',
+      version: 'v0.21',
+      sourceUrl: 'https://github.com/drakmor/ftpsrv'
+    }]
+  )
+
+  assert.equal(status.isInstalled, false)
+  assert.equal(status.isUpdate, true)
+  assert.equal(status.installedFilename, 'ftpsrv-ps5.elf')
+})
+
+test('不同仓库的同名文件不构成更新关系', () => {
+  const status = getPayloadStatus(
+    {
+      filename: 'ftpsrv-ps5.elf',
+      version: '1.15-ng-stable',
+      source_url: 'https://github.com/drakmor/ftpsrv'
+    },
+    [{
+      filename: 'ftpsrv-ps5.elf',
+      version: 'v0.21',
+      sourceUrl: 'https://github.com/ps5-payload-dev/ftpsrv'
+    }]
+  )
+
+  assert.equal(status.isInstalled, false)
+  assert.equal(status.isUpdate, false)
+  assert.equal(status.installedFilename, undefined)
+})
+
+test('缺失仓库 URL 时按源 ID 和源名阻断跨仓库更新', () => {
+  const bySourceId = getPayloadStatus(
+    {
+      filename: 'ftpsrv-ps5.elf',
+      version: '1.15-ng-stable',
+      source_id: 'source_drakmor'
+    },
+    [{
+      filename: 'ftpsrv-ps5.elf',
+      version: 'v0.21',
+      sourceId: 'source_ps5_payload_dev'
+    }]
+  )
+  const bySourceName = getPayloadStatus(
+    {
+      filename: 'ftpsrv-ps5.elf',
+      version: '1.15-ng-stable',
+      source_name: 'drakmor/ftpsrv'
+    },
+    [{
+      filename: 'ftpsrv-ps5.elf',
+      version: 'v0.21',
+      sourceName: 'ps5-payload-dev/ftpsrv'
+    }]
+  )
+
+  assert.equal(bySourceId.isUpdate, false)
+  assert.equal(bySourceName.isUpdate, false)
+})
+
+test('USB 导入的同名文件不构成仓库更新关系', () => {
+  const status = getPayloadStatus(
+    {
+      filename: 'ftpsrv-ps5.elf',
+      version: '1.15-ng-stable',
+      source_url: 'https://github.com/drakmor/ftpsrv'
+    },
+    [{
+      filename: 'ftpsrv-ps5.elf',
+      version: 'v0.21',
+      installSource: 'usb'
+    }]
+  )
+
+  assert.equal(status.isInstalled, false)
+  assert.equal(status.isUpdate, false)
+})
+
+test('挂载 USB 中的文件不作为内部已安装插件参与更新判断', () => {
+  const installedPayloads = getInstalledPayloads(
+    ['/data/pldmgr/ftpsrv-ps5.elf', '/mnt/usb0/pldmgr/ftpsrv-ps5.elf'],
+    {
+      'ftpsrv-ps5.elf': {
+        version: 'v0.21',
+        source: 'source_ftpsrv',
+        source_name: 'ps5-payload-dev/ftpsrv',
+        install_source: 'repository',
+        install_source_detail: 'https://github.com/ps5-payload-dev/ftpsrv'
+      }
+    }
+  )
+
+  assert.deepEqual(installedPayloads, [{
+    filename: 'ftpsrv-ps5.elf',
+    version: 'v0.21',
+    sourceId: 'source_ftpsrv',
+    sourceName: 'ps5-payload-dev/ftpsrv',
+    sourceUrl: 'https://github.com/ps5-payload-dev/ftpsrv',
+    installSource: 'repository'
+  }])
+})


### PR DESCRIPTION
## Problem

When the same payload exists in multiple sources, the storage page flags it as "update available" based on filename + version comparison alone, ignoring which source each side actually came from.

Two forks of the same tool — e.g. `ps5-payload-dev/ftpsrv v0.21` in the official repo and `drakmor/ftpsrv 1.15-ng-stable` in a community source — would show up as updates of each other even though they're different codebases. Installing one would cause the other to prompt an "Update" button, and applying that "update" would silently swap fork implementations.

## Fix

Match on source identity before comparing versions. Resolution order:

1. `source.url` (repository URL the payload was installed from)
2. `source.id`
3. `source.name`
4. Fallback: assume same source (legacy sidecar compatibility)

USB-installed payloads never participate in repo update detection.

## Changes

- `frontend/src/utils/payloadStatus.js` (new): version + source-identity matching logic
- `frontend/src/utils/payloadStatus.test.js` (new): 8 test cases covering cross-fork, missing-identity, USB, and legacy-fallback paths
- `frontend/src/components/views/StorageHub.jsx`: pass `source_id` / `source_name` / `source_url` from each catalog entry into the per-payload status resolver
- `frontend/package.json`: add `npm test` script

## Backward compatibility

Sidecar metadata written before multi-source support lacks source identity fields. These entries fall back to the old same-source behavior, so existing installs don't suddenly change semantics.

## Test plan

```
cd frontend && npm test
```

All 8 tests pass, including:
- Cross-fork same-name payload → no update shown
- Same-source different version → update shown
- USB install → never matches repo update
- Missing source identity → falls back to same-source behavior